### PR TITLE
Replace deprecated dependency in GitHub action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,10 @@
 #     in the "Create Module Archive" step below.
 #
 #   - Is the release tag the proper format?
-#     See the comments for the "Extract Version From Tag" step below.
+#     Format: `<major>.<minor>.<patch>`
+#     Contrary to GitHub's best practices, avoid prefixing the tag with a `v`.
+#     See https://github.com/League-of-Foundry-Developers/FoundryVTT-Module-Template/issues/27
+#     for more information.
 #
 #   - Is a GitHub release being published?
 #     This workflow will only run when a release is published, not when a
@@ -70,20 +73,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
-
-
-      # Extract version embedded in the tag.
-      # This step expects the tag to be one of the following formats:
-      #   - "v<major>.<minor>.<patch>" (e.g., "v1.2.3")
-      #   - "<major>.<minor>.<patch>"  (e.g., "1.2.3")
-      #
-      # The version will be used by later steps to fill in the value for the
-      # "version" key required for a valid module manifest.
-      - name: Extract Version From Tag
-        id: get_version
-        uses: battila7/get-version-action@v2
-
+        uses: actions/checkout@v4
 
       # Modify "module.json" with values specific to the release.
       # Since the values for the "version" and "url" keys aren't known ahead of
@@ -97,11 +87,10 @@ jobs:
         with:
           files: 'module.json'
         env:
-          VERSION: ${{steps.get_version.outputs.version-without-v}}
+          VERSION: ${{ github.event.release.tag_name }}
           URL: ${{ env.project_url }}
           MANIFEST: ${{ env.latest_manifest_url }}
           DOWNLOAD: ${{ env.release_module_url }}
-
 
       # Create a "module.zip" archive containing all the module's required files.
       # If you have other directories or files that will need to be added to
@@ -125,7 +114,6 @@ jobs:
           # Don't forget to add a backslash at the end of the line for any
           # additional files or directories!
 
-
       # Update the GitHub release with the manifest and module archive files.
       - name: Update Release With Files
         id: create_version_release
@@ -133,7 +121,7 @@ jobs:
         with:
           allowUpdates: true
           name: ${{ github.event.release.name }}
-          draft: ${{ github.event.release.unpublished }}
+          draft: false
           prerelease: ${{ github.event.release.prerelease }}
           token: ${{ secrets.GITHUB_TOKEN }}
           artifacts: './module.json, ./module.zip'


### PR DESCRIPTION
Dependency [`get_version`](https://github.com/battila7/get-version-action) hasn't been updated for almost 4 years.
This leads to deprecation of `set-output` command (see https://github.com/battila7/get-version-action/issues/22).