### PR TITLE
Pre-release 3.0.0-zeta: Make history's height flexible-ish again

### DIFF
--- a/scripts/module.mjs
+++ b/scripts/module.mjs
@@ -17,7 +17,7 @@ class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 		},
 		position: {
 			width: 640,
-			height: "auto",
+			height: "auto", // If set to `auto`, setting history's height to 100% results in a minimal height.
 		},
 		tag: "form",
 		window: {

--- a/scripts/module.mjs
+++ b/scripts/module.mjs
@@ -61,7 +61,7 @@ class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 		// TODO: try to avoid using jQuery, e.g.:
 		// this.element.querySelector("input[name=something]").addEventListener("click", /* ... */);
 
-		html.find('input[type="submit"]').click(async _event => {
+		html.find('button[type="submit"]').click(async _event => {
 			await this.sendMessage(html);
 		});
 

--- a/styles/messenger.css
+++ b/styles/messenger.css
@@ -2,11 +2,6 @@
   flex: 0 0 24px;
 }
 
-div.window-app.lame-messenger {
-  width: 660px;
-  height: 576px; /* 4 players: 470, 5 players: 576 */
-}
-
 #lame-messenger {
   /* center all elements */
   text-align: center;
@@ -18,9 +13,12 @@ div.window-app.lame-messenger {
   padding: 0;
 }
 
-#lame-messenger li {
-  display: inline-block;
+#lame-messenger .players li {
   margin-bottom: 10px;
+}
+
+#lame-messenger .players li:last-child {
+  margin-bottom: 0;
 }
 
 #lame-messenger input[type="checkbox"][class~="user-checkmark"] {
@@ -103,14 +101,27 @@ div.window-app.lame-messenger {
 
 #lame-messenger .players {
   float: left;
-  width: 75px;
+  width: 90px; /* could be 75px without scrollbar */
+  max-height: 626px; /* 6 players */
   margin-right: 8px; /* same as application window's inner padding */
+  overflow-y: auto;
 }
 
 #lame-messenger .chat-elements {
-  height: 424px; /* TODO: find a way to make it dynamic again based on the number of players */
   display: flex;
   flex-flow: column;
+  min-height: 626px; /* Applies to 6 players and more. */
+}
+body.vtt:has(#lame-messenger .players li:first-child:nth-last-child(1)) #lame-messenger .chat-elements,
+body.vtt:has(#lame-messenger .players li:first-child:nth-last-child(2)) #lame-messenger .chat-elements,
+body.vtt:has(#lame-messenger .players li:first-child:nth-last-child(3)) #lame-messenger .chat-elements {
+  min-height: 308px;
+}
+body.vtt:has(#lame-messenger .players li:first-child:nth-last-child(4)) #lame-messenger .chat-elements {
+  min-height: 414px;
+}
+body.vtt:has(#lame-messenger .players li:first-child:nth-last-child(5)) #lame-messenger .chat-elements {
+  min-height: 520px;
 }
 
 #lame-messenger textarea {

--- a/styles/messenger.css
+++ b/styles/messenger.css
@@ -97,6 +97,10 @@ div.window-app.lame-messenger {
   margin: 10px 0;
 }
 
+#lame-messenger button[type="submit"] {
+  border: 2px groove;
+}
+
 #lame-messenger .players {
   float: left;
   width: 75px;

--- a/templates/messenger.hbs
+++ b/templates/messenger.hbs
@@ -12,7 +12,10 @@
 </textarea>
 
 		<textarea class="message" name="message" placeholder="{{ localize 'LAME.WhisperHint' }}" rows="3"></textarea>
-		<input type="submit" value="{{ localize 'LAME.Send' }}">
+
+		<button type="submit">
+			<i class="far fa-paper-plane"></i> {{ localize 'LAME.Send' }}
+		</button>
 	</div>
 
 </form>


### PR DESCRIPTION
When setting the application's height to `auto` (in `DEFAULT_OPTIONS`), then setting the history's height to 100% results in a minimal height of the history, as there is no fixed reference value to base the 100% on.

This change now sets the history's minimum height to the equivalent of players being displayed.
The height values are fixed for 1-6 players (not counting yourself).
Having 7 players or more results in a scrollbar showing.

Having only a single user (excluding user role `none`) in the world (AKA "only yourself") is currently not handled, since talking to yourself via the messenger is not supported.

This solution is clunky but acceptable as the goal is to move to a vertical tab-based view anyway.