### PR TITLE
Remove `.gitattributes` file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,0 @@
-# Set the default behavior, in case people don't have core.autocrlf set.
-# This is needed to allow for compatibility of line separators between Windows and MacOS.
-# https://github.com/github/docs/blob/main/content/get-started/getting-started-with-git/configuring-git-to-handle-line-endings.md#example
-* text eol=crlf


### PR DESCRIPTION
The setting for line breaks had no positive effect between my Windows and MacOS computers anyway, and I suspect it might be the culprit for breaking binary files.