### PR TITLE
Remove `.gitattributes` as it breaks binary files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,0 @@
-# Set the default behavior, in case people don't have core.autocrlf set.
-# This is needed to allow for compatibility of line separators between Windows and MacOS.
-# https://github.com/github/docs/blob/main/content/get-started/getting-started-with-git/configuring-git-to-handle-line-endings.md#example
-* text eol=crlf


### PR DESCRIPTION
Finally found the culprit that caused binary files to become corrupt:
It seems Git incorrectly identifies WEBP and OGG files as text files and due to forcing carriage return line feeds (CRLF) in text files (which I though would help with line separator issues between Windows and MacOS but had no effect), a `0d` was prepended to each `0a` (`0d0a` is the [separator used by Windows][1] in text files) in these binary files:

![image](https://github.com/user-attachments/assets/5ee685bd-5860-4c68-a9a0-4b52df401ac0)

And just for good measure, I've also set locally
```
git config --global core.autocrlf false
```
as hinted to in [this Reddit post][2].


[1]: <http://www.maxi-pedia.com/Line+termination+line+feed+versus+carriage+return+0d0a> "Line termination: line feed versus carriage return 0d 0a"
[2]: <https://www.reddit.com/r/git/comments/rukzhi/comment/hr0e47l/> "Reddit: Files are downloaded corrupted/different from origin"