### PR TITLE
Add workflow step to publish release to package page

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,3 +128,13 @@ jobs:
           artifacts: './module.json, ./module.zip'
           tag: ${{ github.event.release.tag_name }}
           body: ${{ github.event.release.body }}
+
+      # Publish the release to the Foundry VTT package page and trigger Discord bot to announce it in #package-release.
+      - name: Publish Module to Foundry VTT Website
+        id: publish-to-foundry-website
+        uses: cs96and/FoundryVTT-release-package@v1
+        with:
+          package-token: ${{ secrets.PACKAGE_TOKEN }}
+          manifest-url: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.json
+          # TODO: Remove dry-run setting after having confirmed it works the first time:
+          dry-run: true

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ If you answered at least one of those questions with "Yes", then LAME Messenger 
 ## ✨ Features
 
 - Dedicated window for sending and receiving whispers with chat history
-- Send a message to multiple recipients at the same time  
+- Send a message to multiple recipients at the same time:  
   ![message sent to two users](https://github.com/lucasmetzen/foundryvtt-messenger/blob/main/docs/README-message-sent-to-two-users.webp?raw=true)
-- Shows a user's avatar or associated actor's image in addition to their name if set in world's user configuration  
+- Shows a user's avatar or associated actor's image in addition to their name if set in world's user configuration:  
   ![message sent to two users](https://github.com/lucasmetzen/foundryvtt-messenger/blob/main/docs/README-user-avatar.webp?raw=true)
 - No need to type `/whisper` command and recipient's username
 - Visual and auditory notification for incoming whisper (optional)
@@ -33,7 +33,7 @@ Note: The module is not a replacement for Foundry VTT's built-in whisper messagi
 
 ## ⚡️ Installation
 
-This module can be installed automatically from the Foundry Virtual Tabletop module browser, or by using the following module manifest url:  
+This module can be installed automatically from the Foundry Virtual Tabletop module browser, or by using the following module manifest URL:  
   https://github.com/lucasmetzen/foundryvtt-messenger/releases/latest/download/module.json
 
 
@@ -41,11 +41,11 @@ This module can be installed automatically from the Foundry Virtual Tabletop mod
 
 - Show notification message for incoming whisper
 - Notification message is displayed until dismissed
-- Show currently disconnected users in user selection  
+- Show currently disconnected users in user selection:  
   ![disconnected users shown](https://github.com/lucasmetzen/foundryvtt-messenger/blob/main/docs/README-disconnected-users-shown.webp?raw=true)
-- Show button in chat sidebar (next to the roll type selector) to open LAME messenger window (shown by default)  
+- Show button in chat sidebar (next to the roll type selector) to open LAME messenger window (shown by default):  
   ![button in chat sidebar](https://github.com/lucasmetzen/foundryvtt-messenger/blob/main/docs/README-button-in-chat-sidebar.webp?raw=true)
-- Show button in scene controls toolbar (left side of screen) to open LAME messenger window  
+- Show button in scene controls toolbar (left side of screen) to open LAME messenger window:  
   ![button in scene controls toolbar](https://github.com/lucasmetzen/foundryvtt-messenger/blob/main/docs/README-button-in-scene-controls-toolbar.webp?raw=true)
 
 


### PR DESCRIPTION
Using the [GitHub action by cs96and](https://github.com/cs96and/FoundryVTT-release-package) allows to automatically add the new release to the [Foundry VTT package page](https://foundryvtt.com/packages/lame-messenger), and triggers Discord bot to announce it in #package-releases.