### PR TITLE
GH workflow: Remove `dry-run` from publish step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,12 +106,13 @@ jobs:
              ./module.zip                        \
             `# The files that will be included.` \
             module.json                          \
+            CHANGELOG.md                         \
             README.md                            \
-            templates/                           \
+            languages/                           \
             scripts/                             \
             sounds/                              \
             styles/                              \
-            languages/
+            templates/
           # Don't forget to add a backslash at the end of the line for any
           # additional files or directories!
 
@@ -136,5 +137,3 @@ jobs:
         with:
           package-token: ${{ secrets.PACKAGE_TOKEN }}
           manifest-url: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.json
-          # TODO: Remove dry-run setting after having confirmed it works the first time:
-          dry-run: true


### PR DESCRIPTION
[Workflow output of release 4.1.0](https://github.com/lucasmetzen/foundryvtt-messenger/actions/runs/12526161814/job/34938434275) looks good, so the `dry-run` setting can be removed from the workflow's publish step.

```
{"id":"lame-messenger","dry-run":true,"release":{"version":"4.1.0","manifest":"https://github.com/lucasmetzen/foundryvtt-messenger/releases/download/4.1.0/module.json","compatibility":{"minimum":"12","verified":"12"},"notes":"https://github.com/lucasmetzen/foundryvtt-messenger/blob/main/CHANGELOG.md"}}
Response: 200 OK
{"status": "success", "page": "https://foundryvtt.com/packages/lame-messenger/edit/", "message": "Dry run completed successfully. To save, submit the request again without dry-run"}
```

This closes #56

This also adds CHANGELOG.md to be included in generated module.zip.