### PR TITLE
GitHub workflow: Add dynamic `notes-url`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -131,9 +131,11 @@ jobs:
           body: ${{ github.event.release.body }}
 
       # Publish the release to the Foundry VTT package page and trigger Discord bot to announce it in #package-release.
+      # https://github.com/cs96and/FoundryVTT-release-package
       - name: Publish Module to Foundry VTT Website
         id: publish-to-foundry-website
         uses: cs96and/FoundryVTT-release-package@v1
         with:
           package-token: ${{ secrets.PACKAGE_TOKEN }}
           manifest-url: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.json
+          notes-url: https://github.com/${{github.repository}}/releases/tag/${{github.event.release.tag_name}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,46 +1,48 @@
-## 4.1.0
+# Lucas's Awesome Messenger Extension, or short: LAME Messenger
+
+## 4.1.0 (2024-12-28)
 ### Improvements
 - Add German localisation
 - Change prioritisation of error messages when trying to send an empty message while not having selected any recipients
 
-## 4.0.1-4.0.4
+## 4.0.1-4.0.4 (2024-12-26)
 - Post-release check fixes (mainly for corrupted binary files due to incorrect CRLF settings in Git)
 - 4.0.4: first version to be added to official package listing after module got approved
 
-## 4.0.0
+## 4.0.0 (2024-12-26)
 First public release and submission to Foundry VTT package listing
 - Bump version number to avoid potential issues with pre-release version numbering
 - Add GitHub workflow step to publish release to package page
 
----
-
-# Versions prior to public release
-
 ## Pre-releases 3.0.0-alpha to -kappa (November and December 2024)
 Multiple pre-releases on the road to public release
-- Minimum Foundry VTT version 12
+- Foundry VTT v12 minimum
 
 ### Improvements
 - Migration to Application v2, and improve sub-templates to match
-- Add settings for whisper notification 
+- Add settings for whisper notification
 - Add settings for UI buttons to open messenger window
 - Rename module from `Lucas's Almost Magnificent Messenger` to `Lucas's Awesome Messenger Extension` and introduce `LAME Messenger` abbreviation
 - Improve overall styling
-- Add GitHub workflow to create module files for release 
+- Add GitHub workflow to create module files for release
 - Add README
 
+---
+
+# Lucas's Almost Magnificent Messenger: versions prior to "modern" development
+
 ## 2.1.3 (July 2021)
-- Compatability with Foundry VTT version 0.8.8
+- Foundry VTT v0.8.8 compatibility
 - Initial Git commit
 
 ## 2.1.2 (April 2021)
-Minimum Foundry VTT version 0.7.9
+Foundry VTT v0.7.9 minimum
 
 ## 1.3.1 (December 2020)
-Minimum Foundry VTT version 0.7.7
+Foundry VTT v0.7.7 minimum
 
 ## 1.3.0 (March 2020)
-Minimum Foundry VTT version 0.5.1
+Foundry VTT v0.5.1 minimum
 
 ## 1.0.0
-Lost to time...
+Lost in the ~~map~~ fog of time...


### PR DESCRIPTION
Pointing the `notes-url` to this specific release is more informative when accessing from the package page and the Discord release post than pointing to the full changelog via https://github.com/lucasmetzen/foundryvtt-messenger/blob/main/CHANGELOG.md.

This also improves the styling of the CHANGELOG.