### PR TITLE
Add customisable keybinding to open Messenger window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Lucas's Awesome Messenger Extension, or short: LAME Messenger
 
+## 4.1.1 (2024-12-28)
+### Improvement
+- Add customisable keybinding to open Messenger window
+
 ## 4.1.0 (2024-12-28)
 ### Improvements
 - Add German localisation

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # ![logo](https://github.com/lucasmetzen/foundryvtt-messenger/blob/main/docs/logo.svg?raw=true) Lucas's Awesome Messenger Extension, or short: LAME Messenger
 
-![Foundry VTT version compatability: v12](https://img.shields.io/badge/Foundry_VTT-v12-informational)
-[![GitHub issues](https://img.shields.io/github/issues/lucasmetzen/foundryvtt-messenger/bug.svg)](https://github.com/lucasmetzen/foundryvtt-messenger/issues/)
+![Foundry VTT version compatibility: v12](https://img.shields.io/badge/Foundry_VTT-v12-informational)
+[![GitHub issues](https://img.shields.io/github/issues/lucasmetzen/foundryvtt-messenger/bug)](https://github.com/lucasmetzen/foundryvtt-messenger/issues/)
+![Latest release ZIP download count](https://img.shields.io/github/downloads/lucasmetzen/foundryvtt-messenger/latest/module.zip)
+![Forge installs](https://img.shields.io/badge/dynamic/json?label=Forge%20Installs&query=package.installs&suffix=%25&url=https%3A%2F%2Fforge-vtt.com%2Fapi%2Fbazaar%2Fpackage%2Flame-messenger&colorB=4aa94a)
 
 LAME Messenger for Foundry VTT provides a simple messenger interface to easily whisper messages.
 
@@ -22,10 +24,10 @@ If you answered at least one of those questions with "Yes", then LAME Messenger 
 - Dedicated window for sending and receiving whispers with chat history
 - Send a message to multiple recipients at the same time:  
   ![message sent to two users](https://github.com/lucasmetzen/foundryvtt-messenger/blob/main/docs/README-message-sent-to-two-users.webp?raw=true)
+- Visual and auditory notification for incoming whisper (optional)
+- No need to type `/whisper` command and recipient's username in Foundry VTT's chat box
 - Shows a user's avatar or associated actor's image in addition to their name if set in world's user configuration:  
   ![message sent to two users](https://github.com/lucasmetzen/foundryvtt-messenger/blob/main/docs/README-user-avatar.webp?raw=true)
-- No need to type `/whisper` command and recipient's username
-- Visual and auditory notification for incoming whisper (optional)
 - Messenger window opens upon receiving a whisper (optional) 
 
 Note: The module is not a replacement for Foundry VTT's built-in whisper messaging but is an additional graphical interface.
@@ -61,6 +63,7 @@ This module can be installed automatically from the Foundry Virtual Tabletop mod
 - Configurable notification sound
 - Configurable keyboard shortcuts (insert line break while typing message, and send message)
 - Option to show the character's portrait image instead of the user's avatar if the user has an associated actor
+- Possibly allow user defined RegularExpressions to filter certain received whispers. 
 
 
 ## 🩹 Troubleshooting

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This module can be installed automatically from the Foundry Virtual Tabletop mod
   ![button in chat sidebar](https://github.com/lucasmetzen/foundryvtt-messenger/blob/main/docs/README-button-in-chat-sidebar.webp?raw=true)
 - Show button in scene controls toolbar (left side of screen) to open LAME messenger window:  
   ![button in scene controls toolbar](https://github.com/lucasmetzen/foundryvtt-messenger/blob/main/docs/README-button-in-scene-controls-toolbar.webp?raw=true)
-
+- Customisable keyboard shortcut for opening the window (via "Configure Controls" dialogue)
 
 ## 🚧 Current limitations
 
@@ -59,7 +59,7 @@ This module can be installed automatically from the Foundry Virtual Tabletop mod
 
 - Tabbed chat for each user
 - Configurable notification sound
-- Configurable keyboard shortcuts (open window, insert line break while typing message, and send message)
+- Configurable keyboard shortcuts (insert line break while typing message, and send message)
 - Option to show the character's portrait image instead of the user's avatar if the user has an associated actor
 
 

--- a/languages/de.json
+++ b/languages/de.json
@@ -31,6 +31,10 @@
     "IncomingWhisperFrom": "Flüsternachricht von",
     "NoUsersToShow": "Kein Nutzer anzuzeigen.",
     "NoUsersToShowExplanation": "Entweder bist du der einzige Nutzer in dieser Welt, alle anderen Nutzen sind deaktiviert, oder sie sind inaktiv und die Einstellung um inaktive Nutzer anzuzeigen ist deaktiviert.",
-    "UserIsOffline": "Kann nur an verbundene Nutzer senden."
+    "UserIsOffline": "Kann nur an verbundene Nutzer senden.",
+    "Keybinding": {
+      "OpenMessengerWindow": "Öffne LAME Messenger-Fenster",
+      "OpenMessengerWindowHint": "Die standardmäßig zugewiesene Strg-Taste ist die linke. Du kannst auch eine Tastenkombination mit der rechten Strg-Taste zuweisen, auch wenn dies im Eingabefeld nicht ersichtlich ist."
+    }
   }
 }

--- a/languages/en.json
+++ b/languages/en.json
@@ -31,6 +31,10 @@
     "IncomingWhisperFrom": "Whisper from",
     "NoUsersToShow": "No users to show.",
     "NoUsersToShowExplanation": "Either you are the only user in the world, all other users are banned, or they are inactive and the setting to show inactive ones is disabled.",
-    "UserIsOffline": "Can't send to user as they are offline."
+    "UserIsOffline": "Can't send to user as they are offline.",
+    "Keybinding": {
+      "OpenMessengerWindow": "Open LAME Messenger window",
+      "OpenMessengerWindowHint": "By default, the assigned Ctrl key is the left one. You can hover also assign a key combination with Right Ctrl, even though it might look the same in the input field."
+    }
   }
 }

--- a/scripts/keybindings.mjs
+++ b/scripts/keybindings.mjs
@@ -1,0 +1,24 @@
+import {localize, MODULE_ID} from "./config.mjs";
+
+export function registerKeybindings() {
+	registerKeybinding("openMessengerWindow", {
+		name: localize("LAME.Keybinding.OpenMessengerWindow"),
+		hint: localize("LAME.Keybinding.OpenMessengerWindowHint"),
+		// TODO: Add "focus/bring to foreground if open".
+		editable: [
+			{
+				key: "KeyM",
+				modifiers: ["Control"]
+			}
+		],
+		onDown: () => {
+			window.LAME.render();
+			return true; // Consume event and prevent execution of other keybind actions.
+		},
+		precedence: CONST.KEYBINDING_PRECEDENCE.NORMAL
+	});
+}
+
+function registerKeybinding(action, data) {
+	return game.keybindings.register(MODULE_ID, action, data);
+}

--- a/scripts/module.mjs
+++ b/scripts/module.mjs
@@ -2,6 +2,7 @@ const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;
 
 import {localize, MODULE_ID, MODULE_ICON_CLASSES, TEMPLATE_PARTS_PATH} from "./config.mjs";
 import {getSetting, registerSettings} from "./settings.mjs";
+import {registerKeybindings} from "./keybindings.mjs";
 import {registerHandlebarsHelpers} from "./helpers/handlebars-helpers.mjs";
 
 class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
@@ -96,6 +97,7 @@ class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 
 	static async init() {
 		registerSettings();
+		registerKeybindings();
 		registerHandlebarsHelpers();
 		window.LAME = new LAME();
 	}


### PR DESCRIPTION
The keybinding defaults to `Ctrl+M` and is fully editable.

---

Also, 386e0ec49664958fd4fa3bf02ae41e1e66382df0 adds count badges for latest release's ZIP download and Forge installation:
![image](https://github.com/user-attachments/assets/495ee1de-706b-4352-b652-9fad234089f3)
