### PR TITLE
Scroll history to bottom when receiving whisper

### DIFF
--- a/scripts/module.mjs
+++ b/scripts/module.mjs
@@ -137,7 +137,12 @@ class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 	}
 
 	async renderHistoryPartial() {
-		await this.renderPart('history');
+		const historyPartialId = "history";
+		await this.renderPart(historyPartialId);
+
+		// Scroll history text area to bottom:
+		const history = document.getElementById(`${MODULE_ID}-${historyPartialId}`);
+		history.scrollTop = history.scrollHeight;
 	}
 
 	computeUsersData() {


### PR DESCRIPTION
This avoids having to manually scroll (esp. since partial render resets position every time).
This behaviour will (have to be) reworked when tabbed chats are introduced.

This closes #67