### PR TITLE
✨Populate history from world's messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ If you answered at least one of those questions with "Yes", then LAME Messenger 
 - No need to type `/whisper` command and recipient's username in Foundry VTT's chat box
 - Shows a user's avatar or associated actor's image in addition to their name if set in world's user configuration:  
   ![message sent to two users](https://github.com/lucasmetzen/foundryvtt-messenger/blob/main/docs/README-user-avatar.webp?raw=true)
-- Messenger window opens upon receiving a whisper (optional) 
+- Messenger window opens upon receiving a whisper (optional)
+- Messages are only stored once (by core Foundry VTT), and processed by LAME Messenger to populate its history in memory: no additional disc space is used.
 
 Note: The module is not a replacement for Foundry VTT's built-in whisper messaging but is an additional graphical interface.
 
@@ -62,6 +63,7 @@ This module can be installed automatically from the Foundry Virtual Tabletop mod
 - Messages not sent privately as a whisper (AKA "public" or dice rolls) are not handled by LAME Messenger. Public chat might be included in a future release.
 - When a player connects or disconnects while you have players selected to send to, the selection is cleared as the players list is re-rendered. As a tabbed window solution is planned for the near future which will change most of the UI anyway, this won't be fixed at the moment. Apologies for this initial inconvenience.
 - Game systems send some status messages privately (e.g. when items or experience are awarded). While all private messages containing dice rolls (e.g. self or GM rolls) are already filtered, there surely will be some which LAME Messenger is going to treat as actual whispers. If you come across any, please report them via the [GitHub issue tracker](https://github.com/lucasmetzen/foundryvtt-messenger/issues/new?assignees=lucasmetzen&labels=filter+system+message&projects=&template=request--filter-game-system-message.md&title=%5BFILTER+REQUEST%5D).
+- Whispers sent from the sidebar's chat box are not included in LAME Messenger's history (unless you reload the browser which populates the history based on the messages saved in the world).
 
 
 ## 💡 Planned features

--- a/scripts/helpers/date-time-helpers.mjs
+++ b/scripts/helpers/date-time-helpers.mjs
@@ -1,0 +1,16 @@
+export function isToday(date) {
+	const today = new Date();
+	return date.setHours(0, 0, 0, 0) === today.setHours(0, 0, 0, 0);
+}
+
+export function formatTimeHHMMSS(date) {
+	return padLeadingZero(date.getHours()) + ":" + padLeadingZero(date.getMinutes()) + ":" + padLeadingZero(date.getSeconds());
+}
+
+export function formatDateYYYYMMDD(date) {
+	return date.getFullYear() + "-" + padLeadingZero(date.getMonth()+1) + "-" + padLeadingZero(date.getDate());
+}
+
+function padLeadingZero(num) {
+	return ('00' + num).slice(-2);
+}

--- a/scripts/helpers/handlebars-helpers.mjs
+++ b/scripts/helpers/handlebars-helpers.mjs
@@ -1,6 +1,6 @@
 export function registerHandlebarsHelpers() {
     Handlebars.registerHelper("isAtLeastOneUserToBeShown", function () {
-        return window.LAME.users.length > 0;
+        return Object.keys(window.LAME.users).length > 0;
     });
 
     // TODO: Try to improve this process: (https://github.com/lucasmetzen/foundryvtt-messenger/issues/25)

--- a/scripts/helpers/i18n.mjs
+++ b/scripts/helpers/i18n.mjs
@@ -1,0 +1,23 @@
+import {MODULE_ID} from "../config.mjs";
+
+const fallbackLocale = "en";
+
+export function i18nLongConjunct(text) {
+	const conjunctionFormatter = new Intl.ListFormat(computeEffectiveLocale(), {
+		style: "long",
+		type: "conjunction",
+	});
+
+	return conjunctionFormatter.format(text);
+}
+
+function computeEffectiveLocale() {
+	const locale = game.i18n.lang;
+	return isCurrentLocaleAvailableInModule(locale) ? locale : fallbackLocale;
+}
+
+
+function isCurrentLocaleAvailableInModule(locale) {
+	const moduleLanguages = game.modules.get(MODULE_ID).languages;
+	return !!(moduleLanguages.find(modLang => modLang.lang === locale));
+}

--- a/scripts/module.mjs
+++ b/scripts/module.mjs
@@ -4,6 +4,7 @@ import {localize, MODULE_ID, MODULE_ICON_CLASSES, TEMPLATE_PARTS_PATH} from "./c
 import {getSetting, registerSettings} from "./settings.mjs";
 import {registerKeybindings} from "./keybindings.mjs";
 import {registerHandlebarsHelpers} from "./helpers/handlebars-helpers.mjs";
+import {formatDateYYYYMMDD, formatTimeHHMMSS, isToday} from "./helpers/date-time-helpers.mjs";
 
 class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 
@@ -119,23 +120,16 @@ class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 	beautifyHistory() {
 		// TODO: I think this is called too often and the output should be cached if it isn't already.
 		let beautified = [];
-		/* Date#toLocaleTimeString calls a "big database of localization strings,
-		 * which is potentially inefficient." Intl.DateTimeFormat is recommended:
-		 * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString
-		 */
-		const usersTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-		const dtFormat = new Intl.DateTimeFormat(undefined, {
-			dateStyle: 'short',
-			timeStyle: 'short',
-			hour12: false,
-			timeZone: usersTimeZone
-		});
 
 		for (let msg of this.history) {
-			let toOrFrom = localize(msg[1] === 'in' ? "LAME.History.From" : "LAME.History.To"),
-				time = dtFormat.format(msg[0]); // TODO: Improve date format in history before merging.
+			const timestamp = msg[0],
+				date = new Date(timestamp),
+				formattedTime = formatTimeHHMMSS(date),
+				displayTime = (!isToday(date)) ? formatDateYYYYMMDD(date) + " " + formattedTime : formattedTime,
+				toOrFrom = localize(msg[1] === 'in' ? "LAME.History.From" : "LAME.History.To");
+
 			beautified.push(
-				`[${time}] ${toOrFrom} ${msg[2]}: ${msg[3]}` // [time] to/from [player name]: [message]
+				`[${displayTime}] ${toOrFrom} ${msg[2]}: ${msg[3]}` // [time] to/from [player name]: [message]
 			);
 		}
 		return beautified;

--- a/scripts/module.mjs
+++ b/scripts/module.mjs
@@ -154,13 +154,13 @@ class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 
 			// Everything left are public messages.
 		}
-
-		log('Internal history populated from world messages');
 	}
 
 	async render(...args) {
 		if (!this.rendered) {
-			return await super.render(true, ...args);
+			await super.render(true, ...args);
+			this.scrollHistoryToBottom();
+			return;
 		}
 
 		await super.render(false);
@@ -177,11 +177,12 @@ class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 	}
 
 	async renderHistoryPartial() {
-		const historyPartialId = "history";
-		await this.renderPart(historyPartialId);
+		await this.renderPart("history");
+		this.scrollHistoryToBottom();
+	}
 
-		// Scroll history text area to bottom:
-		const history = document.getElementById(`${MODULE_ID}-${historyPartialId}`);
+	scrollHistoryToBottom() {
+		const history = document.getElementById(`${MODULE_ID}-history`);
 		history.scrollTop = history.scrollHeight;
 	}
 

--- a/scripts/module.mjs
+++ b/scripts/module.mjs
@@ -5,6 +5,7 @@ import {getSetting, registerSettings} from "./settings.mjs";
 import {registerKeybindings} from "./keybindings.mjs";
 import {registerHandlebarsHelpers} from "./helpers/handlebars-helpers.mjs";
 import {formatDateYYYYMMDD, formatTimeHHMMSS, isToday} from "./helpers/date-time-helpers.mjs";
+import {i18nLongConjunct} from "./helpers/i18n.mjs";
 
 class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 
@@ -315,9 +316,9 @@ class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 
 	addOutgoingTextToHistory(recipientNames, text, timestamp = null) {
 		if (!timestamp) timestamp = Date.now();
-		for (const recipientName of recipientNames) {
-			this.history.push([timestamp, 'out', recipientName, text]);
-		}
+		const conjunctedRecipientNames = i18nLongConjunct(recipientNames);
+		// As Foundry can only send messages to a single recipient, the conjunction is only kept for in-memory history.
+		this.history.push([timestamp, 'out', conjunctedRecipientNames, text]);
 	}
 
 	isPublicMessage(msg) {

--- a/scripts/module.mjs
+++ b/scripts/module.mjs
@@ -326,12 +326,10 @@ class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 	}
 
 	isWhisperForMe(msg) {
-		if (!msg.whisper.length  // Ignore public messages,
-			|| msg.isAuthor      // outgoing whispers,
 		if (msg.isAuthor      // outgoing whispers,
-			|| !msg.visible      // whispers where the current user is neither author nor recipient,
-			|| msg.isRoll)       // and private dice rolls.
-			return false;
+			|| !msg.visible   // whispers where the current user is neither author nor recipient,
+			|| msg.isRoll     // and private dice rolls.
+		) return false;
 
 		return true;
 	}

--- a/scripts/module.mjs
+++ b/scripts/module.mjs
@@ -105,8 +105,9 @@ class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 		window.LAME = new LAME();
 	}
 
-	static ready() {
+	static async ready() {
 		window.LAME.computeUsersData(); // TODO: Look into this again as this doesn't seem to be the intended way...
+		await window.LAME.populateHistoryFromWorldMessages();
 	}
 
 	static async hookCreateChatMessage(msg, _options, _senderUserId) {
@@ -118,13 +119,45 @@ class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 	beautifyHistory() {
 		// TODO: I think this is called too often and the output should be cached if it isn't already.
 		let beautified = [];
+		/* Date#toLocaleTimeString calls a "big database of localization strings,
+		 * which is potentially inefficient." Intl.DateTimeFormat is recommended:
+		 * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString
+		 */
+		const usersTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+		const dtFormat = new Intl.DateTimeFormat(undefined, {
+			dateStyle: 'short',
+			timeStyle: 'short',
+			hour12: false,
+			timeZone: usersTimeZone
+		});
+
 		for (let msg of this.history) {
-			let toOrFrom = localize(msg[1] === 'in' ? "LAME.History.From" : "LAME.History.To");
+			let toOrFrom = localize(msg[1] === 'in' ? "LAME.History.From" : "LAME.History.To"),
+				time = dtFormat.format(msg[0]); // TODO: Improve date format in history before merging.
 			beautified.push(
-				`[${msg[0]}] ${toOrFrom} ${msg[2]}: ${msg[3]}` // [time] to/from [player name]: [message]
+				`[${time}] ${toOrFrom} ${msg[2]}: ${msg[3]}` // [time] to/from [player name]: [message]
 			);
 		}
 		return beautified;
+	}
+
+	async populateHistoryFromWorldMessages() {
+		const worldMessages = game.collections.get("ChatMessage").contents;
+		for (const msg of worldMessages) {
+			if (this.isMessageASystemMessage(msg)) continue;
+
+			if (msg.isAuthor) {
+				this.addOutgoingMessageToHistory(msg);
+				continue;
+			}
+
+			if (this.isWhisperForMe(msg))
+				this.addIncomingMessageToHistory(msg);
+
+			// Everything left are public messages.
+		}
+
+		log('Internal history populated from world messages');
 	}
 
 	async render(...args) {
@@ -158,7 +191,7 @@ class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 		const showInactiveUsers = getSetting('showInactiveUsers'),
 			usersToExclude = getSetting("usersToExclude");
 
-		let usersData = [];
+		let usersData = {};
 		for (let user of game.users) {
 			// TODO: instead of skipping self, banned, excluded, and non-active users here,
 			//  consider including all and simply add attribute(s) like "ignore".
@@ -167,13 +200,12 @@ class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 			// Skip inactive user unless inactive users should be shown:
 			if (!user.active && !showInactiveUsers) continue;
 
-			let data = {
+			usersData[user.id] = {
 				name: user.name,
 				id: user.id,
 				avatar: user.avatar,
 				active: user.active // user currently connected
 			};
-			usersData.push(data);
 		}
 		window.LAME.users = usersData;
 	}
@@ -205,8 +237,8 @@ class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 	async sendMessage(html) {
 		// Get message text:
 		const messageField = html.find('.message'),
-			message = messageField.val();
-		if (message.length === 0) {
+			messageText = messageField.val();
+		if (messageText.length === 0) {
 			ui.notifications.error(localize("LAME.Notification.NoMessageToSend"));
 			return;
 		}
@@ -223,8 +255,8 @@ class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 		}
 
 		// Send whisper(s):
-		this.sendWhisperTo(selectedUserNames, message);
-		this.addOutgoingMessageToHistory(selectedUserNames, message);
+		this.sendWhisperTo(selectedUserNames, messageText);
+		this.addOutgoingTextToHistory(selectedUserNames, messageText);
 		await this.renderHistoryPartial();
 
 		// Clear message input field for next text:
@@ -264,24 +296,30 @@ class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 		});
 	}
 
-	currentTime() {
-		function padLeadingZero(num) {
-			return ('00' + num).slice(-2);
+	addIncomingMessageToHistory(msg) {
+		this.addIncomingTextToHistory(msg.author.name, msg.content, msg.timestamp)
+	}
+
+	addIncomingTextToHistory(authorName, text, timestamp) {
+		this.history.push([timestamp, 'in', authorName, text]);
+	}
+
+	addOutgoingMessageToHistory(msg) {
+		function getUserNameFromId(id) {
+			// If user does not exist, it was either deleted in the world, or is excluded via settings.
+			if (!window.LAME.users[id]) return "unknown";
+
+			return window.LAME.users[id].name;
 		}
 
-		const date = new Date();
-		return padLeadingZero(date.getHours()) + ":" + padLeadingZero(date.getMinutes()) + ":" + padLeadingZero(date.getSeconds());
+		const recipientNames = msg.whisper.map(id => getUserNameFromId(id));
+		this.addOutgoingTextToHistory(recipientNames, msg.content, msg.timestamp);
 	}
 
-	addIncomingMessageToHistory(data) {
-		const time = this.currentTime();
-		this.history.push([time, 'in', data.author.name, data.content]);
-	}
-
-	addOutgoingMessageToHistory(recipients, msg) {
-		for (const recipient of recipients) {
-			const time = this.currentTime();
-			this.history.push([time, 'out', recipient, msg]);
+	addOutgoingTextToHistory(recipientNames, text, timestamp = null) {
+		if (!timestamp) timestamp = Date.now();
+		for (const recipientName of recipientNames) {
+			this.history.push([timestamp, 'out', recipientName, text]);
 		}
 	}
 


### PR DESCRIPTION
As LAME Messenger does not store its own processed copies of the sent and received whispers, its history is empty when a user logs in or reloads the browser.

This change now parses core Foundry VTT's stored messages (`game.collections.get("ChatMessage").contents`) to populate the in-memory history on `ready` hook.

This closes #78

---

Additionally, the time stamp of each whisper now also shows the date is the message wasn't received today:
![image](https://github.com/user-attachments/assets/d140e6cb-fe82-426f-9141-7ac9a54d0a51)
This only applies to whispers _populated during `ready`_ (at the moment).