### PR TITLE
📖️README: Add Foundry Hub endorsement badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ LAME Messenger for Foundry VTT provides a simple messenger interface to easily w
 
 ![Foundry VTT version compatibility: v12](https://img.shields.io/badge/Foundry_VTT-v12-informational)
 [![GitHub issues](https://img.shields.io/github/issues/lucasmetzen/foundryvtt-messenger/bug)](https://github.com/lucasmetzen/foundryvtt-messenger/issues/)
-![Latest release download count](https://img.shields.io/github/downloads/lucasmetzen/foundryvtt-messenger/latest/module.zip?label=latest+release+download+count)
+![Latest release download count](https://img.shields.io/github/downloads/lucasmetzen/foundryvtt-messenger/latest/module.zip?label=latest+release+downloads)
 ![Forge installs](https://img.shields.io/badge/dynamic/json?label=Forge%20Installs&query=package.installs&suffix=%25&url=https%3A%2F%2Fforge-vtt.com%2Fapi%2Fbazaar%2Fpackage%2Flame-messenger&colorB=4aa94a)
+[![Foundry Hub endorsements](https://img.shields.io/endpoint?logoColor=white&url=https%3A%2F%2Fwww.foundryvtt-hub.com%2Fwp-json%2Fhubapi%2Fv1%2Fpackage%2Flame-messenger%2Fshield%2Fendorsements&label=Hub%20endorsements)](https://www.foundryvtt-hub.com/package/lame-messenger/)
 
 ![LAME Messenger interface introduction](https://github.com/lucasmetzen/foundryvtt-messenger/blob/main/docs/README-introduction.webp?raw=true)
 


### PR DESCRIPTION
Now that the first endorsement on [Foundry Hub](https://www.foundryvtt-hub.com/package/lame-messenger/) was received (🥳), let's add the badge:
![image](https://github.com/user-attachments/assets/ffa98a0e-61df-4bf4-a9cf-91074f7deb10)
![image](https://github.com/user-attachments/assets/0db92ecc-4b1b-44f5-bdba-dd0283ff3d02)
