### PR TITLE
🐛Refactor user exclusion to fix inactive users author handling

### DIFF
--- a/templates/parts/users.hbs
+++ b/templates/parts/users.hbs
@@ -1,8 +1,8 @@
 <section>
     {{#if (isAtLeastOneUserToBeShown)}}
         <ul>
-            {{#each users}}
-                {{#with this}}
+            {{#each users}}{{#with this}}
+                {{#unless exclude}}
                     <li {{#unless active}} class="offline" title="{{ localize 'LAME.UserIsOffline' }}" {{/unless}}>
                         <input type="checkbox" id="lame-messenger-user-{{id}}" class="user-checkmark" {{#unless active}} disabled {{/unless}} />
                         <label for="lame-messenger-user-{{id}}">
@@ -12,8 +12,8 @@
                             <p>{{name}}</p>
                         </label>
                     </li>
-                {{/with}}
-            {{/each}}
+                {{/unless}}
+            {{/with}}{{/each}}
         </ul>
     {{else}}
         <div class="no-users-to-show">


### PR DESCRIPTION
Since data of currently inactive (disconnected) and excluded users is not included in the `usersData` object, during history population, whispers having been sent by one such user get indicated as originating from `unknown`:

<img width="873" alt="Image" src="https://github.com/user-attachments/assets/0d8b7437-4a28-4821-8828-3982fdf81c10" />

This change refactors the computation of users data to include _all_ users present in the world instead of not including those either inactive or set to be excluded.

This closes #104