### PR TITLE
Fix showing "no users to show" hint

### DIFF
--- a/scripts/helpers/handlebars-helpers.mjs
+++ b/scripts/helpers/handlebars-helpers.mjs
@@ -1,6 +1,6 @@
 export function registerHandlebarsHelpers() {
     Handlebars.registerHelper("isAtLeastOneUserToBeShown", function () {
-        return Object.keys(this.users).length > 0;
+        return Object.values(this.users).some(user => !user.exclude);
     });
 
     Handlebars.registerHelper("userColor", function (userId) {

--- a/styles/messenger.css
+++ b/styles/messenger.css
@@ -170,7 +170,7 @@ body.theme-light #lame-messenger .history {
     flex-flow: column;
     min-height: 638px; /* Applies to 6 players and more. */
 }
-body.vtt:has(#lame-messenger .users.no-users-to-show) #lame-messenger .chat-elements,
+body.vtt:has(#lame-messenger .users .no-users-to-show) #lame-messenger .chat-elements,
 body.vtt:has(#lame-messenger .users li:first-child:nth-last-child(1)) #lame-messenger .chat-elements,
 body.vtt:has(#lame-messenger .users li:first-child:nth-last-child(2)) #lame-messenger .chat-elements,
 body.vtt:has(#lame-messenger .users li:first-child:nth-last-child(3)) #lame-messenger .chat-elements {


### PR DESCRIPTION
As the check is based on the number of users present in the `users` object, the check now never fails since disconnected and to exclude users are always present.

This also decreases the height of the window if no users are shown (as originally intended to the same height as for 3 users or less).