### PR TITLE
Finalise v13 compatibility verification

### DIFF
--- a/module.json
+++ b/module.json
@@ -6,14 +6,14 @@
   "library": "false",
   "compatibility": {
     "minimum": "12",
-    "verified": "12.331",
-    "maximum": "13.334"
+    "verified": "13.344"
   },
   "authors": [
     {
       "name": "Zandaarl",
       "url": "https://github.com/lucasmetzen",
-      "discord": "zandaarl"
+      "discord": "zandaarl",
+      "flags": {}
     }
   ],
   "esmodules": [
@@ -26,12 +26,14 @@
     {
       "lang": "de",
       "name": "Deutsch",
-      "path": "languages/de.json"
+      "path": "languages/de.json",
+      "flags": {}
     },
     {
       "lang": "en",
       "name": "English",
-      "path": "languages/en.json"
+      "path": "languages/en.json",
+      "flags": {}
     }
   ],
   "url": "#{URL}#",

--- a/scripts/helpers/version-helpers.mjs
+++ b/scripts/helpers/version-helpers.mjs
@@ -1,4 +1,0 @@
-export function foundryCoreVersion() {
-	let version = game.version.split(".");
-	return {major: parseInt(version[0]), minor: version[1]};
-}

--- a/scripts/lame.mjs
+++ b/scripts/lame.mjs
@@ -6,7 +6,6 @@ import {registerKeybindings} from "./keybindings.mjs";
 import {registerHandlebarsHelpers} from "./helpers/handlebars-helpers.mjs";
 import {formatDateYYYYMMDD, formatTimeHHMMSS, isToday} from "./helpers/date-time-helpers.mjs";
 import {i18nLongConjunct} from "./helpers/i18n.mjs";
-import {foundryCoreVersion} from "./helpers/version-helpers.mjs";
 
 export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 
@@ -134,7 +133,7 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 	}
 
 	static onCollapseSidebar(_app, collapsed) {
-		if (foundryCoreVersion().major < 13) return;
+		if (game.release.generation < 13) return;
 
 		// Inspired by ChatLog#_toggleNotifications()
 		const embedInput = (!collapsed && ui.chat.active);
@@ -143,7 +142,7 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 	}
 
 	static onChangeSidebarTab(app) {
-		if (foundryCoreVersion().major < 13) return;
+		if (game.release.generation < 13) return;
 
 		// TODO: Check if this can be done differently without triggering so many times, possibly not doing anything at all.
 		//  Consider adding boolean member #chatbarVisible or similar.

--- a/scripts/lame.mjs
+++ b/scripts/lame.mjs
@@ -167,6 +167,7 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 			|| !instance.isWhisperForMe(msg)
 			|| instance.isMessageGameSystemGenerated(msg)
 			|| instance.isMessageGameSystemSpecificRoll(msg)
+			|| instance.isMessageModuleGenerated(msg)
 		) return;
 
 		await instance.handleIncomingPrivateMessage(msg);
@@ -200,6 +201,7 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 			if (this.isPublicMessage(msg)
 				|| this.isMessageGameSystemGenerated(msg)
 				|| this.isMessageGameSystemSpecificRoll(msg)
+				|| this.isMessageModuleGenerated(msg)
 			) continue;
 
 			if (msg.isAuthor) {
@@ -437,7 +439,8 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 			'<h3 class="nue">Inviting Your Players</h3>', // core
 			'<span class=\"award-entry\">',               // dnd5e: "[character] has been awarded [...]"
 			'<p class="requestmessage">'                  // wfrp4e: skill tests
-		]
+		];
+
 		return systemGens.some((item) => msg.content.includes(item));
 	}
 
@@ -449,5 +452,14 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 		)) return true;
 
 		return false;
+	}
+
+	isMessageModuleGenerated(msg) {
+		const moduleWelcomes = [
+			'<div class="dice-so-nice">',  // Dice So Nice
+			'<p>Welcome to Plutonium!</p>' // Plutonium
+		];
+
+		return moduleWelcomes.some((item) => msg.content.includes(item));
 	}
 }

--- a/scripts/module.mjs
+++ b/scripts/module.mjs
@@ -1,7 +1,6 @@
 import {LAME} from "./lame.mjs";
 import {getSetting} from "./settings.mjs";
 import {localize, MODULE_ICON_CLASSES, MODULE_ID} from "./config.mjs";
-import {foundryCoreVersion} from "./helpers/version-helpers.mjs";
 
 Hooks.once('init', LAME.init); // this feels VERY early in Foundry's initialisation...
 
@@ -17,7 +16,7 @@ Hooks.once('ready', async() => {
 
 // v12: Add button to scene controls toolbar:
 Hooks.on('renderSceneControls', (_controls, html) => {
-	if (!getSetting("buttonInSceneControlToolbar") || foundryCoreVersion().major > 12) return;
+	if (!getSetting("buttonInSceneControlToolbar") || game.release.generation > 12) return;
 
 	const messengerBtn = $(
 		`<li class="scene-control control-tool toggle" data-tooltip="LAME.Module.ShortTitle">
@@ -37,7 +36,7 @@ Hooks.on("changeSidebarTab", LAME.onChangeSidebarTab);
 
 // v13+: Add button to chat controls:
 Hooks.on("renderChatLog", async (_app, htmlPassed, _data_ChatInput) => {
-	if (foundryCoreVersion().major < 13) return;
+	if (game.release.generation < 13) return;
 
 	const html = htmlPassed instanceof jQuery ? htmlPassed[0] : htmlPassed,
 		instance = game.modules.get(MODULE_ID).instance;
@@ -56,7 +55,7 @@ Hooks.on("renderChatLog", async (_app, htmlPassed, _data_ChatInput) => {
 
 // v12: Add button to chat controls:
 Hooks.on("renderSidebarTab", async (app, html, _data) => {
-	if (foundryCoreVersion().major > 12) return;
+	if (game.release.generation > 12) return;
 
 	if (app.tabName !== "chat" || !getSetting("buttonInChatControls")) return;
 

--- a/scripts/settings.mjs
+++ b/scripts/settings.mjs
@@ -1,9 +1,8 @@
 import {MODULE_ID} from "./config.mjs";
-import {foundryCoreVersion} from "./helpers/version-helpers.mjs";
 import {LAME} from "./lame.mjs";
 
 export function registerSettings() {
-	const isCoreV12orLower = foundryCoreVersion().major < 13;
+	const isCoreV12orLower = game.release.generation < 13;
 
 	registerSetting('showNotificationForNewWhisper', {
 		name: "LAME.Setting.ShowNotificationForNewWhisper",


### PR DESCRIPTION
Concludes compatibility verification after stable Foundry VTT v13 release.

This also includes removing `#foundryCoreVersion` function in favor of using core member attribute, as well as filtering welcome messages of modules "Dice So Nice!" and "Plutonium".