### PR TITLE
Add support for Foundry VTT v14

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -39,7 +39,7 @@
     "UserIsOffline": "Can't send to user as they are offline.",
     "Keybinding": {
       "OpenMessengerWindow": "Open LAME Messenger window",
-      "OpenMessengerWindowHint": "By default, the assigned Ctrl key is the left one. You can hover also assign a key combination with Right Ctrl, even though it might look the same in the input field."
+      "OpenMessengerWindowHint": "By default, the assigned Ctrl key is the left one. You can also assign a key combination with Right Ctrl, even though it might look the same in the input field."
     }
   }
 }

--- a/module.json
+++ b/module.json
@@ -6,7 +6,7 @@
   "library": "false",
   "compatibility": {
     "minimum": "12",
-    "verified": "13.344"
+    "verified": "14.356"
   },
   "authors": [
     {

--- a/module.json
+++ b/module.json
@@ -6,7 +6,7 @@
   "library": "false",
   "compatibility": {
     "minimum": "12",
-    "verified": "14.356"
+    "verified": "14.365"
   },
   "authors": [
     {

--- a/scripts/lame.mjs
+++ b/scripts/lame.mjs
@@ -1,5 +1,3 @@
-import {log} from "./helpers/log.mjs";
-
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;
 
 import {localize, MODULE_ID, MODULE_ICON_CLASSES, TEMPLATE_PARTS_PATH} from "./config.mjs";
@@ -131,27 +129,36 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 		registerSettings();
 		registerKeybindings();
 		registerHandlebarsHelpers();
+
 		const instance = new LAME();
-
-		if (game.release.generation > 12) {
-			const additionStylingClass = (game.release.generation === 13) ? 'lame-styling-v13' : 'lame-styling-post-v13';
-			let messengerBtnHtml = `<div id="lame-messenger-button" class="split-button ${additionStylingClass}">
-				<button type="button" class="ui-control icon ${MODULE_ICON_CLASSES}" data-tooltip="LAME.Module.ShortTitle"
-				data-action="TODO" aria-pressed="false" aria-label=""></button>
-			</div>`; // TODO: Either fill in or remove `data-action` attribute if unused.
-			instance.chatbarButton = (game.release.generation < 13)
-				? foundry.applications.parseHTML(messengerBtnHtml)
-				: foundry.utils.parseHTML(messengerBtnHtml);
-			instance.chatbarButton.addEventListener('click', async (_event) => {
-				await game.modules.get(MODULE_ID).instance.show();
-			});
-		}
-
+		instance.chatbarButton = LAME.generateChatbarButton();
 		game.modules.get(MODULE_ID).instance = instance;
-		log('init done')
 	}
 
+	static generateChatbarButton() {
+		let chatbarButtonHtml;
+		if (game.release.generation < 13) {
+			chatbarButtonHtml = `
+				<a aria-label="${localize("LAME.Module.ShortTitle")}" role="button" class="lame-messenger" data-tooltip="LAME.Module.ShortTitle">
+					<i class="${MODULE_ICON_CLASSES}"></i>
+				</a>`;
+		} else {
+			chatbarButtonHtml = `<div id="lame-messenger-button" class="split-button">
+					<button type="button" class="ui-control icon ${MODULE_ICON_CLASSES}" data-tooltip="LAME.Module.ShortTitle"
+					aria-pressed="false"></button>
+				</div>`;
+		}
+		
+		let chatbarButton = (game.release.generation < 13)
+			? foundry.applications.parseHTML(chatbarButtonHtml)
+			: foundry.utils.parseHTML(chatbarButtonHtml);
+		chatbarButton.addEventListener('click', async (_event) => {
+			await game.modules.get(MODULE_ID).instance.show();
+		});
 
+		return chatbarButton;
+	}
+	
 	static onCollapseSidebar(_app, collapsed) {
 		if (game.release.generation < 13) return;
 

--- a/scripts/lame.mjs
+++ b/scripts/lame.mjs
@@ -1,3 +1,5 @@
+import {log} from "./helpers/log.mjs";
+
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;
 
 import {localize, MODULE_ID, MODULE_ICON_CLASSES, TEMPLATE_PARTS_PATH} from "./config.mjs";
@@ -129,8 +131,26 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 		registerSettings();
 		registerKeybindings();
 		registerHandlebarsHelpers();
-		game.modules.get(MODULE_ID).instance = new LAME();
+		const instance = new LAME();
+
+		if (game.release.generation > 12) {
+			const additionStylingClass = (game.release.generation === 13) ? 'lame-styling-v13' : 'lame-styling-post-v13';
+			let messengerBtnHtml = `<div id="lame-messenger-button" class="split-button ${additionStylingClass}">
+				<button type="button" class="ui-control icon ${MODULE_ICON_CLASSES}" data-tooltip="LAME.Module.ShortTitle"
+				data-action="TODO" aria-pressed="false" aria-label=""></button>
+			</div>`; // TODO: Either fill in or remove `data-action` attribute if unused.
+			instance.chatbarButton = (game.release.generation < 13)
+				? foundry.applications.parseHTML(messengerBtnHtml)
+				: foundry.utils.parseHTML(messengerBtnHtml);
+			instance.chatbarButton.addEventListener('click', async (_event) => {
+				await game.modules.get(MODULE_ID).instance.show();
+			});
+		}
+
+		game.modules.get(MODULE_ID).instance = instance;
+		log('init done')
 	}
+
 
 	static onCollapseSidebar(_app, collapsed) {
 		if (game.release.generation < 13) return;
@@ -152,12 +172,14 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 
 	static moveChatbarButtonToSidebar(){
 		const chatbarButton = game.modules.get(MODULE_ID).instance.chatbarButton;
-		document.querySelector("#roll-privacy").insertAdjacentElement("afterend", chatbarButton);
+		// TODO: Check if there is a Foundry way to avoid manipulating the WHOLE document...
+		const selector = (game.release.generation < 14) ? "#roll-privacy" : "#message-modes";
+		document.querySelector(selector).after(chatbarButton);
 	}
 
 	static moveChatbarButtonToNotificationArea(){
 		const chatbarButton = game.modules.get(MODULE_ID).instance.chatbarButton;
-		document.getElementById("chat-notifications").append(chatbarButton);
+		document.getElementById("chat-controls").prepend(chatbarButton);
 	}
 
 	static async onCreateChatMessage(msg, _options, _senderUserId) {
@@ -243,6 +265,8 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 		const instance = game.modules.get(MODULE_ID).instance;
 		if (!instance.rendered) await instance.render();
 	}
+
+	_canDetach() { return false; }
 
 	scrollHistoryToBottom() {
 		const history = document.getElementById(`${MODULE_ID}-history`);

--- a/scripts/lame.mjs
+++ b/scripts/lame.mjs
@@ -177,14 +177,14 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 		else LAME.moveChatbarButtonToNotificationArea();
 	}
 
-	static moveChatbarButtonToSidebar(){
+	static moveChatbarButtonToSidebar() {
 		const chatbarButton = game.modules.get(MODULE_ID).instance.chatbarButton;
-		// TODO: Check if there is a Foundry way to avoid manipulating the WHOLE document...
+		// TODO: Check if there is a Foundry way to use a scoped sidebar part of the DOM instead of document.
 		const selector = (game.release.generation < 14) ? "#roll-privacy" : "#message-modes";
 		document.querySelector(selector).after(chatbarButton);
 	}
 
-	static moveChatbarButtonToNotificationArea(){
+	static moveChatbarButtonToNotificationArea() {
 		const chatbarButton = game.modules.get(MODULE_ID).instance.chatbarButton;
 		document.getElementById("chat-controls").prepend(chatbarButton);
 	}

--- a/scripts/module.mjs
+++ b/scripts/module.mjs
@@ -1,6 +1,6 @@
 import {LAME} from "./lame.mjs";
 import {getSetting} from "./settings.mjs";
-import {localize, MODULE_ICON_CLASSES, MODULE_ID} from "./config.mjs";
+import {MODULE_ICON_CLASSES, MODULE_ID} from "./config.mjs";
 import {log} from "./helpers/log.mjs";
 
 Hooks.once('init', LAME.init); // this feels VERY early in Foundry's initialisation...
@@ -9,9 +9,10 @@ Hooks.once('ready', async () => {
 	const instance = game.modules.get(MODULE_ID).instance;
 	instance.computeUsersData(); // TODO: Look into this again as this doesn't seem to be the intended way...
 	await instance.populateHistoryFromWorldMessages();
-	// TODO: Check if there is a better way for the initial moving of the button to the notification area,
-	//  as we just _assume_ the sidebar is collapsed.
-	// Initially display button in notification area as sidebar is usually collapsed:
+
+	// TODO: Check if there is a better way for the initial adding of the button to the notification area.
+	//   Could use `renderChatLog` (or check if e.g. `renderChatNotification` exists). But I'd say it's fine for now.
+	// Initial display button in notification area if sidebar is collapsed:
 	if (!ui.sidebar.expanded) LAME.onCollapseSidebar(undefined, true);
 });
 
@@ -19,58 +20,30 @@ Hooks.once('ready', async () => {
 Hooks.on('renderSceneControls', (_controls, html) => {
 	if (!getSetting("buttonInSceneControlToolbar") || game.release.generation > 12) return;
 	
-	const messengerBtn = $(
-		`<li class="scene-control control-tool toggle" data-tooltip="LAME.Module.ShortTitle">
-			<i class="${MODULE_ICON_CLASSES}"></i>
-		</li>`
-	);
-	messengerBtn[0].addEventListener('click', async (_event) => {
+	const scenecontrolButtonHtml = `<li class="scene-control control-tool toggle" data-tooltip="LAME.Module.ShortTitle">
+				<i class="${MODULE_ICON_CLASSES}"></i>
+			</li>`;
+	let scenecontrolButton = foundry.applications.parseHTML(scenecontrolButtonHtml);
+	scenecontrolButton.addEventListener('click', async (_event) => {
 		await game.modules.get(MODULE_ID).instance.show();
 	});
 	
-	html.find('.control-tools').find('.scene-control').last().after(messengerBtn);
-});
-
-Hooks.on("collapseSidebar", LAME.onCollapseSidebar);
-Hooks.on("changeSidebarTab", LAME.onChangeSidebarTab);
-
-// v13+: Add button to chat controls (in expanded sidebar element):
-Hooks.on("renderChatLog", async (_app, htmlPassed, _data_ChatInput) => {
-	// This seems to be called only once.
-	
-	if (game.release.generation < 13) return;
-	
-	const html = htmlPassed instanceof jQuery ? htmlPassed[0] : htmlPassed,
-		chatbarButton = game.modules.get(MODULE_ID).instance.chatbarButton;
-	
-	if (game.release.generation === 13) {
-		html.querySelector(".chat-controls").insertAdjacentElement("afterbegin", chatbarButton);
-	} else {
-		// document.querySelector("#chat-controls").before(instance.chatbarButton);
-		document.querySelector("#message-modes").after(chatbarButton); // CORRECT position in sidebar!
-		log('renderChatLog > added button')
-		// TODO: if this works, simplify by only changing the selector as variable.
-	}
+	html.find('.control-tools').find('.scene-control').last().after(scenecontrolButton);
+	log('renderSceneControls > button added')
 });
 
 // v12: Add button to chat controls:
 Hooks.on("renderSidebarTab", async (app, html, _data) => {
 	if (game.release.generation > 12) return;
-	
+
 	if (app.tabName !== "chat" || !getSetting("buttonInChatControls")) return;
 	
-	const messengerBtn = $(
-		`<a aria-label="${localize("LAME.Module.ShortTitle")}" role="button" class="lame-messenger" data-tooltip="LAME.Module.ShortTitle">
-			<i class="${MODULE_ICON_CLASSES}"></i>
-		</a>`
-	);
-	messengerBtn[0].addEventListener('click', async (_event) => {
-		await game.modules.get(MODULE_ID).instance.show();
-	});
-	
-	html.find("#chat-controls select.roll-type-select").after(messengerBtn);
+	const chatbarButton = game.modules.get(MODULE_ID).instance.chatbarButton;
+	html.find("#chat-controls select.roll-type-select").after(chatbarButton);
 });
 
+Hooks.on("collapseSidebar", LAME.onCollapseSidebar);
+Hooks.on("changeSidebarTab", LAME.onChangeSidebarTab);
 Hooks.on("createChatMessage", LAME.onCreateChatMessage);
 
 // Update internal player list when user (dis)connects:

--- a/scripts/module.mjs
+++ b/scripts/module.mjs
@@ -1,10 +1,11 @@
 import {LAME} from "./lame.mjs";
 import {getSetting} from "./settings.mjs";
 import {localize, MODULE_ICON_CLASSES, MODULE_ID} from "./config.mjs";
+import {log} from "./helpers/log.mjs";
 
 Hooks.once('init', LAME.init); // this feels VERY early in Foundry's initialisation...
 
-Hooks.once('ready', async() => {
+Hooks.once('ready', async () => {
 	const instance = game.modules.get(MODULE_ID).instance;
 	instance.computeUsersData(); // TODO: Look into this again as this doesn't seem to be the intended way...
 	await instance.populateHistoryFromWorldMessages();
@@ -17,48 +18,47 @@ Hooks.once('ready', async() => {
 // v12: Add button to scene controls toolbar:
 Hooks.on('renderSceneControls', (_controls, html) => {
 	if (!getSetting("buttonInSceneControlToolbar") || game.release.generation > 12) return;
-
+	
 	const messengerBtn = $(
 		`<li class="scene-control control-tool toggle" data-tooltip="LAME.Module.ShortTitle">
 			<i class="${MODULE_ICON_CLASSES}"></i>
 		</li>`
 	);
-	messengerBtn[0].addEventListener('click', async(_event) => {
+	messengerBtn[0].addEventListener('click', async (_event) => {
 		await game.modules.get(MODULE_ID).instance.show();
 	});
-
+	
 	html.find('.control-tools').find('.scene-control').last().after(messengerBtn);
 });
-
 
 Hooks.on("collapseSidebar", LAME.onCollapseSidebar);
 Hooks.on("changeSidebarTab", LAME.onChangeSidebarTab);
 
-// v13+: Add button to chat controls:
+// v13+: Add button to chat controls (in expanded sidebar element):
 Hooks.on("renderChatLog", async (_app, htmlPassed, _data_ChatInput) => {
+	// This seems to be called only once.
+	
 	if (game.release.generation < 13) return;
-
+	
 	const html = htmlPassed instanceof jQuery ? htmlPassed[0] : htmlPassed,
-		instance = game.modules.get(MODULE_ID).instance;
-
-	let messengerBtnHtml = `<div id="lame-messenger-button" class="split-button">
-		<button type="button" class="ui-control icon ${MODULE_ICON_CLASSES}" data-tooltip="LAME.Module.ShortTitle"
-		data-action="TODO" aria-pressed="false" aria-label=""></button>
-	</div>`;
-	instance.chatbarButton = foundry.applications.parseHTML(messengerBtnHtml);
-	instance.chatbarButton.addEventListener('click', async(_event) => {
-		await game.modules.get(MODULE_ID).instance.show();
-	});
-
-	html.querySelector(".chat-controls").insertAdjacentElement("afterbegin", instance.chatbarButton);
+		chatbarButton = game.modules.get(MODULE_ID).instance.chatbarButton;
+	
+	if (game.release.generation === 13) {
+		html.querySelector(".chat-controls").insertAdjacentElement("afterbegin", chatbarButton);
+	} else {
+		// document.querySelector("#chat-controls").before(instance.chatbarButton);
+		document.querySelector("#message-modes").after(chatbarButton); // CORRECT position in sidebar!
+		log('renderChatLog > added button')
+		// TODO: if this works, simplify by only changing the selector as variable.
+	}
 });
 
 // v12: Add button to chat controls:
 Hooks.on("renderSidebarTab", async (app, html, _data) => {
 	if (game.release.generation > 12) return;
-
+	
 	if (app.tabName !== "chat" || !getSetting("buttonInChatControls")) return;
-
+	
 	const messengerBtn = $(
 		`<a aria-label="${localize("LAME.Module.ShortTitle")}" role="button" class="lame-messenger" data-tooltip="LAME.Module.ShortTitle">
 			<i class="${MODULE_ICON_CLASSES}"></i>
@@ -67,7 +67,7 @@ Hooks.on("renderSidebarTab", async (app, html, _data) => {
 	messengerBtn[0].addEventListener('click', async (_event) => {
 		await game.modules.get(MODULE_ID).instance.show();
 	});
-
+	
 	html.find("#chat-controls select.roll-type-select").after(messengerBtn);
 });
 

--- a/styles/messenger.css
+++ b/styles/messenger.css
@@ -14,13 +14,9 @@
     bottom: 1px;
 }
 
-/* v13: When the sidebar is collapsed: */
+/* core v13+: When the sidebar is collapsed: */
 #chat-notifications #lame-messenger-button {
-    position: absolute;
-    inset: auto auto 0 calc(100% + 16px); /* core's "Chat Notifications" is set to `pips` */
-}
-body.vtt:has(#chat-notifications #roll-privacy) #chat-notifications #lame-messenger-button {
-    inset: auto auto 144px calc(100% + 16px); /* bottom = 4 * --control-size (=32px) + 16px */
+    margin-bottom: 8px; /* same as `gap` of core's sidebar menus */
 }
 
 /* Counteract parent's `display: flex` which breaks the users section's `float: left`,


### PR DESCRIPTION
## ✨ Add support for UI changes in Foundry VTT v14

- Core v14 changes the DOM structure regarding the position and CSS classes of the sidebar's chat controls (both in expanded and collapsed state which was introduced in v13), breaking the insertion logic of the Messenger button. This is fixed.

## ♻️ Under the hood changes

- The Messenger button is now more appropriately positioned in the DOM to take advantage of Foundry's flexible visual positioning and styling, when the sidebar is collapsed. This allows the button to accommodate possible presences of other module's icons without overlapping and situations were there are less icons than the default "message mode" icons a GM sees.
- Some refactoring has been made to reduce code duplication which was present to handle differences between v13 and v14.