### PR TITLE
Support Foundry's chat notification setting "pip"

### DIFF
--- a/scripts/lame.mjs
+++ b/scripts/lame.mjs
@@ -1,3 +1,5 @@
+import {log} from "./helpers/log.mjs";
+
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;
 
 import {localize, MODULE_ID, MODULE_ICON_CLASSES, TEMPLATE_PARTS_PATH} from "./config.mjs";
@@ -179,6 +181,8 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 
 	static moveChatbarButtonToSidebar() {
 		const chatbarButton = game.modules.get(MODULE_ID).instance.chatbarButton;
+		chatbarButton.classList.remove('standalone-for-pip'); // In case this is present.
+		
 		// TODO: Check if there is a Foundry way to use a scoped sidebar part of the DOM instead of document.
 		const selector = (game.release.generation < 14) ? "#roll-privacy" : "#message-modes";
 		document.querySelector(selector).after(chatbarButton);
@@ -186,7 +190,36 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 
 	static moveChatbarButtonToNotificationArea() {
 		const chatbarButton = game.modules.get(MODULE_ID).instance.chatbarButton;
-		document.getElementById("chat-controls").prepend(chatbarButton);
+		if (game.settings.get('core', 'uiConfig').chatNotifications === 'pip') {
+			LAME.addChatbarButtonToNotificationAreaAsStandalone();
+		} else {
+			document.getElementById("chat-controls").prepend(chatbarButton);
+		}
+	}
+
+	// v13+: Add/Remove standalone Messenger button when chat notification is set to pip/cards, respectively.
+	static onClientSettingChanged(settingPath, options) {
+		if (settingPath !== "core.uiConfig" || game.release.generation < 13) return;
+		
+		const instance = game.modules.get(MODULE_ID).instance,
+			chatbarButton = instance.chatbarButton;
+		
+		if (options.chatNotifications === "pip") {
+			LAME.addChatbarButtonToNotificationAreaAsStandalone();
+			log("Chat Notifications setting changed to 'pip': added Messenger button as standalone to notifications area.")
+		} else if (options.chatNotifications === "cards") {
+			chatbarButton.classList.remove('standalone-for-pip');
+			// Foundry calls `renderChatInput` hook before `clientSettingChanged` to render the `#chat-controls` element.
+			//   We can therefore move the button ourselves without using `Hooking.once("renderChatInput")` for timing.
+			LAME.moveChatbarButtonToNotificationArea();
+			log("Chat Notifications setting changed to 'cards': removed standalone Messenger button from notifications area.")
+		}
+	}
+
+	static addChatbarButtonToNotificationAreaAsStandalone() {
+		const chatbarButton = game.modules.get(MODULE_ID).instance.chatbarButton;
+		document.getElementById("chat-notifications").append(chatbarButton);
+		chatbarButton.classList.add('standalone-for-pip');
 	}
 
 	static async onCreateChatMessage(msg, _options, _senderUserId) {

--- a/scripts/module.mjs
+++ b/scripts/module.mjs
@@ -9,11 +9,18 @@ Hooks.once('ready', async () => {
 	const instance = game.modules.get(MODULE_ID).instance;
 	instance.computeUsersData(); // TODO: Look into this again as this doesn't seem to be the intended way...
 	await instance.populateHistoryFromWorldMessages();
-
-	// TODO: Check if there is a better way for the initial adding of the button to the notification area.
-	//   Could use `renderChatLog` (or check if e.g. `renderChatNotification` exists). But I'd say it's fine for now.
-	// Initial display button in notification area if sidebar is collapsed:
-	if (!ui.sidebar.expanded) LAME.onCollapseSidebar(undefined, true);
+	
+	if (game.release.generation > 12) {
+		const settingPipOrCards = game.settings.get('core', 'uiConfig').chatNotifications; // "cards" | "pip" (default)
+		if (settingPipOrCards === 'cards') {
+			// TODO: Check if there is a better way for the initial adding of the button to the notification area.
+			//   Could use `renderChatLog` (or check if e.g. `renderChatNotification` exists). But I'd say it's fine for now.
+			// Initial display button in notification area if sidebar is collapsed:
+			if (!ui.sidebar.expanded) LAME.onCollapseSidebar(undefined, true);
+		} else {
+			LAME.addChatbarButtonToNotificationAreaAsStandalone();
+		}
+	}
 });
 
 // v12: Add button to scene controls toolbar:
@@ -48,3 +55,5 @@ Hooks.on("createChatMessage", LAME.onCreateChatMessage);
 
 // Update internal player list when user (dis)connects:
 Hooks.on('userConnected', LAME.computeUsersDataAndRenderPartial);
+
+Hooks.on('clientSettingChanged', LAME.onClientSettingChanged);

--- a/styles/messenger.css
+++ b/styles/messenger.css
@@ -15,8 +15,15 @@
 }
 
 /* core v13+: When the sidebar is collapsed: */
-#chat-notifications #lame-messenger-button {
+#lame-messenger-button {
     margin-bottom: 8px; /* same as `gap` of core's sidebar menus */
+}
+
+/* core v13+: When chat notifications are set to "pip" and Button is added as standalone: */
+#lame-messenger-button.standalone-for-pip {
+    position: absolute;
+    inset: auto auto 0 calc(100% + 16px);
+    margin-bottom: 0;
 }
 
 /* Counteract parent's `display: flex` which breaks the users section's `float: left`,


### PR DESCRIPTION
## ✨ Support Foundry's chat notification setting "pip"

Since Foundry v13, there is a UI option to set the chat notification to either "chat cards" or "notification pip" (a red dot on the sidebar's chat icon) to notify about incoming messages when the sidebar is collapsed.
When set to pip, the usual 4 chat control buttons are removed when the sidebar is collapsed. As the Messenger button is inserted into that menu, it is also removed.

This change now handles this by inserting the button as standalone into the notification area:
<img width="273" height="204" alt="Image" src="https://github.com/user-attachments/assets/0e3039a5-04f1-4ba0-aeff-c16d48fb2081" />

Situations handled:
- Loading the page with "pip" setting.
- Loading the page with "cards" setting.
- Changing the setting from "pip" to "cards".
- Changing the setting from "cards" to "pip".

As there is no third setting and Foundry's default is "pip", this covers the full range of options.