### PR TITLE
Refactoring, mostly members encapsulation

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -1,7 +1,6 @@
 {
   "LAME": {
     "Module": {
-      "LongTitle": "Lucas's Awesome Messenger Extension",
       "ShortTitle": "LAME Messenger",
       "TitleWithAbbreviation": "Lucas's Awesome Messenger Extension (LAME Messenger)"
     },

--- a/scripts/config.mjs
+++ b/scripts/config.mjs
@@ -3,9 +3,10 @@ export const MODULE_ID = "lame-messenger",
 	CONSOLE_LOG_PREFIX = "LAME Messenger";
 
 const PATH = `modules/${MODULE_ID}`,
-	TEMPLATE_PATH = `${PATH}/templates`;
+	TEMPLATES_PATH = `${PATH}/templates`;
 
-export const TEMPLATE_PARTS_PATH = `${TEMPLATE_PATH}/parts`;
+export const SOUNDS_PATH = `${PATH}/sounds`,
+	TEMPLATE_PARTS_PATH = `${TEMPLATES_PATH}/parts`;
 
 export function localize(stringId) {
 	return game.i18n.localize(stringId);

--- a/scripts/keybindings.mjs
+++ b/scripts/keybindings.mjs
@@ -1,5 +1,5 @@
 import {localize, MODULE_ID} from "./config.mjs";
-import {LAME} from "./lame.mjs";
+import {Lame} from "./lame.mjs";
 
 export function registerKeybindings() {
 	registerKeybinding("openMessengerWindow", {
@@ -13,7 +13,7 @@ export function registerKeybindings() {
 			}
 		],
 		onDown: async() => {
-			await game.modules.get(MODULE_ID).instance.show();
+			await Lame.show();
 			return true; // Consume event and prevent execution of other keybind actions.
 		},
 		precedence: CONST.KEYBINDING_PRECEDENCE.NORMAL

--- a/scripts/lame.mjs
+++ b/scripts/lame.mjs
@@ -1,4 +1,4 @@
-import {localize, MODULE_ID, MODULE_ICON_CLASSES, TEMPLATE_PARTS_PATH, SOUNDS_PATH} from "./config.mjs";
+import {localize, MODULE_ICON_CLASSES, TEMPLATE_PARTS_PATH, SOUNDS_PATH} from "./config.mjs";
 import {getSetting, registerSettings} from "./settings.mjs";
 import {registerKeybindings} from "./keybindings.mjs";
 import {registerHandlebarsHelpers} from "./helpers/handlebars-helpers.mjs";
@@ -7,6 +7,13 @@ import {i18nLongConjunct} from "./helpers/i18n.mjs";
 import {log} from "./helpers/log.mjs";
 
 const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;
+
+/**
+ * Expose the LAME HandlebarsApplication instance.
+ * This simplifies accessing it via `game.modules.get(MODULE_ID).instance`.
+ * @type {LAME}
+ */
+export let Lame;
 
 export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 
@@ -52,16 +59,16 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 	}
 
 	/**
-	 * The button in the chat sidebar to open the Messenger.
-	 * @type {HTMLDivElement}
+	 * The object holding HTML elements of LAME's UI for easy access.
+	 * @type {{chatbarButton: HTMLDivElement}}
 	 */
-	static chatbarButton;
+	ui = {};
 
 	/**
 	 * The internally relevant users' data. Populated by {@link computeUsersData}.
 	 * @type {Object || Array}
 	 */
-	static users;
+	users;
 
 	/** @inheritDoc */
 	get title() {
@@ -131,12 +138,11 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 		registerKeybindings();
 		registerHandlebarsHelpers();
 
-		const instance = new LAME();
-		instance.chatbarButton = LAME.generateChatbarButton();
-		game.modules.get(MODULE_ID).instance = instance;
+		Lame = new LAME();
+		Lame.ui.chatbarButton = Lame.generateChatbarButton(); // TODO: Rename it as it's not always in the chatbar.
 	}
 
-	static generateChatbarButton() {
+	generateChatbarButton() {
 		let chatbarButtonHtml;
 		if (game.release.generation < 13) {
 			chatbarButtonHtml = `
@@ -154,83 +160,77 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 			? foundry.applications.parseHTML(chatbarButtonHtml)
 			: foundry.utils.parseHTML(chatbarButtonHtml);
 		chatbarButton.addEventListener('click', async (_event) => {
-			await game.modules.get(MODULE_ID).instance.show();
+			await Lame.show();
 		});
 
 		return chatbarButton;
 	}
 
-	static onCollapseSidebar(_app, collapsed) {
+	onCollapseSidebar(_app, collapsed) {
 		if (game.release.generation < 13) return;
 
 		// Inspired by ChatLog#_toggleNotifications()
 		const embedInput = (!collapsed && ui.chat.active);
-		if (embedInput) LAME.moveChatbarButtonToSidebar()
-		else LAME.moveChatbarButtonToNotificationArea();
+		// Here, as in all static functions (needed for Hooks), `this` is the Hook object.
+		if (embedInput) Lame.moveChatbarButtonToSidebar()
+		else Lame.moveChatbarButtonToNotificationArea();
 	}
 
-	static onChangeSidebarTab(app) {
+	onChangeSidebarTab(app) {
 		if (game.release.generation < 13) return;
 
 		// TODO: Check if this can be done differently without triggering so many times, possibly not doing anything at all.
 		//  Consider adding boolean member #chatbarVisible or similar.
-		if (app.id === "chat") LAME.moveChatbarButtonToSidebar()
-		else LAME.moveChatbarButtonToNotificationArea();
+		if (app.id === "chat") Lame.moveChatbarButtonToSidebar()
+		else Lame.moveChatbarButtonToNotificationArea();
 	}
 
-	static moveChatbarButtonToSidebar() {
-		const chatbarButton = game.modules.get(MODULE_ID).instance.chatbarButton;
-		chatbarButton.classList.remove('standalone-for-pip'); // In case this is present.
+	moveChatbarButtonToSidebar() {
+		this.ui.chatbarButton.classList.remove('standalone-for-pip'); // In case this is present.
 
 		// TODO: Check if there is a Foundry way to use a scoped sidebar part of the DOM instead of document.
 		const selector = (game.release.generation < 14) ? "#roll-privacy" : "#message-modes";
-		document.querySelector(selector).after(chatbarButton);
+		document.querySelector(selector).after(this.ui.chatbarButton);
 	}
 
-	static moveChatbarButtonToNotificationArea() {
-		const chatbarButton = game.modules.get(MODULE_ID).instance.chatbarButton;
+	moveChatbarButtonToNotificationArea() {
 		if (game.settings.get('core', 'uiConfig').chatNotifications === 'pip') {
-			LAME.addChatbarButtonToNotificationAreaAsStandalone();
+			Lame.addChatbarButtonToNotificationAreaAsStandalone();
 		} else {
-			document.getElementById("chat-controls").prepend(chatbarButton);
+			document.getElementById("chat-controls").prepend(this.ui.chatbarButton);
 		}
 	}
 
 	// v13+: Add/Remove standalone Messenger button when chat notification is set to pip/cards, respectively.
-	static onClientSettingChanged(settingPath, options) {
+	onClientSettingChanged(settingPath, options) {
 		if (settingPath !== "core.uiConfig" || game.release.generation < 13) return;
 
-		const instance = game.modules.get(MODULE_ID).instance,
-			chatbarButton = instance.chatbarButton;
-
 		if (options.chatNotifications === "pip") {
-			LAME.addChatbarButtonToNotificationAreaAsStandalone();
+			Lame.addChatbarButtonToNotificationAreaAsStandalone();
 			log("Chat Notifications setting changed to 'pip': added Messenger button as standalone to notifications area.")
 		} else if (options.chatNotifications === "cards") {
-			chatbarButton.classList.remove('standalone-for-pip');
+			Lame.ui.chatbarButton.classList.remove('standalone-for-pip'); // Works.
 			// Foundry calls `renderChatInput` hook before `clientSettingChanged` to render the `#chat-controls` element.
 			//   We can therefore move the button ourselves without using `Hooking.once("renderChatInput")` for timing.
-			LAME.moveChatbarButtonToNotificationArea();
+			Lame.moveChatbarButtonToNotificationArea();
 			log("Chat Notifications setting changed to 'cards': removed standalone Messenger button from notifications area.")
 		}
 	}
 
-	static addChatbarButtonToNotificationAreaAsStandalone() {
-		const chatbarButton = game.modules.get(MODULE_ID).instance.chatbarButton;
-		document.getElementById("chat-notifications").append(chatbarButton);
-		chatbarButton.classList.add('standalone-for-pip');
+	addChatbarButtonToNotificationAreaAsStandalone() {
+		document.getElementById("chat-notifications").append(Lame.ui.chatbarButton);
+		Lame.ui.chatbarButton.classList.add('standalone-for-pip');
 	}
 
-	static async onCreateChatMessage(msg, _options, _senderUserId) {
-		const instance = game.modules.get(MODULE_ID).instance;
-		if (instance.isPublicMessage(msg)
-			|| !instance.isWhisperForMe(msg)
-			|| instance.isMessageGameSystemGenerated(msg)
-			|| instance.isMessageGameSystemSpecificRoll(msg)
-			|| instance.isMessageModuleGenerated(msg)
+	async onCreateChatMessage(msg, _options, _senderUserId) {
+		if (Lame.isPublicMessage(msg)
+			|| !Lame.isWhisperForMe(msg)
+			|| Lame.isMessageGameSystemGenerated(msg)
+			|| Lame.isMessageGameSystemSpecificRoll(msg)
+			|| Lame.isMessageModuleGenerated(msg)
 		) return;
 
-		await instance.handleIncomingPrivateMessage(msg);
+		await Lame.handleIncomingPrivateMessage(msg);
 	}
 
 	beautifyHistory() {
@@ -301,14 +301,13 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 
 	// Without this, when pressing Ctrl+M while window is already shown, the window is incorrectly re-rendered fully.
 	async show() {
-		const instance = game.modules.get(MODULE_ID).instance;
-		if (!instance.rendered) await instance.render();
+		if (!this.rendered) await this.render();
 	}
 
 	_canDetach() { return false; }
 
 	scrollHistoryToBottom() {
-		const history = document.getElementById(`${MODULE_ID}-history`);
+		const history = this.parts.history;
 		history.scrollTop = history.scrollHeight;
 	}
 
@@ -364,10 +363,9 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 		this.users = usersData;
 	}
 
-	static async computeUsersDataAndRenderPartial() {
-		const instance = game.modules.get(MODULE_ID).instance;
-		instance.computeUsersData();
-		await instance.renderPart('users');
+	async computeUsersDataAndRenderPartial() {
+		Lame.computeUsersData();
+		await Lame.renderPart('users');
 	}
 
 	sendWhisperTo(userIds, msg) {

--- a/scripts/lame.mjs
+++ b/scripts/lame.mjs
@@ -86,7 +86,7 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 	async _preparePartContext(partId, context) {
 		switch ( partId ) {
 			case "history":
-				context.history = this.beautifyHistory();
+				context.history = this.#beautifyHistory();
 				break;
 			case "users":
 				context.users = this.users;
@@ -111,7 +111,7 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 		// Attach actions to elements:
 		// TODO: Adopt AppV2's "actions" instead.
 		this.element.querySelector('button.send').addEventListener('click', async () => {
-			await this.sendMessage();
+			await this.#sendMessage();
 		});
 
 		Lame.ui.messageField = this.element.querySelector('.message');
@@ -119,7 +119,7 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 			await this._onKeyPressEvent(event);
 		});
 
-		this.scrollHistoryToBottom();
+		this.#scrollHistoryToBottom();
 	}
 
 	static async onSubmit(_event, _form, _formData) { }
@@ -138,10 +138,10 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 		registerHandlebarsHelpers();
 
 		Lame = new LAME();
-		Lame.ui.chatbarButton = Lame.generateChatbarButton(); // TODO: Rename it as it's not always in the chatbar.
+		Lame.ui.chatbarButton = Lame.#generateChatbarButton(); // TODO: Rename it as it's not always in the chatbar.
 	}
 
-	generateChatbarButton() {
+	#generateChatbarButton() {
 		let chatbarButtonHtml;
 		if (game.release.generation < 13) {
 			chatbarButtonHtml = `
@@ -171,8 +171,8 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 		// Inspired by ChatLog#_toggleNotifications()
 		const embedInput = (!collapsed && ui.chat.active);
 		// Here, as in all static functions (needed for Hooks), `this` is the Hook object.
-		if (embedInput) Lame.moveChatbarButtonToSidebar()
-		else Lame.moveChatbarButtonToNotificationArea();
+		if (embedInput) Lame.#moveChatbarButtonToSidebar()
+		else Lame.#moveChatbarButtonToNotificationArea();
 	}
 
 	onChangeSidebarTab(app) {
@@ -180,11 +180,11 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 
 		// TODO: Check if this can be done differently without triggering so many times, possibly not doing anything at all.
 		//  Consider adding boolean member #chatbarVisible or similar.
-		if (app.id === "chat") Lame.moveChatbarButtonToSidebar()
-		else Lame.moveChatbarButtonToNotificationArea();
+		if (app.id === "chat") Lame.#moveChatbarButtonToSidebar()
+		else Lame.#moveChatbarButtonToNotificationArea();
 	}
 
-	moveChatbarButtonToSidebar() {
+	#moveChatbarButtonToSidebar() {
 		this.ui.chatbarButton.classList.remove('standalone-for-pip'); // In case this is present.
 
 		// TODO: Check if there is a Foundry way to use a scoped sidebar part of the DOM instead of document.
@@ -192,7 +192,7 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 		document.querySelector(selector).after(this.ui.chatbarButton);
 	}
 
-	moveChatbarButtonToNotificationArea() {
+	#moveChatbarButtonToNotificationArea() {
 		if (game.settings.get('core', 'uiConfig').chatNotifications === 'pip') {
 			Lame.addChatbarButtonToNotificationAreaAsStandalone();
 		} else {
@@ -211,7 +211,7 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 			Lame.ui.chatbarButton.classList.remove('standalone-for-pip'); // Works.
 			// Foundry calls `renderChatInput` hook before `clientSettingChanged` to render the `#chat-controls` element.
 			//   We can therefore move the button ourselves without using `Hooking.once("renderChatInput")` for timing.
-			Lame.moveChatbarButtonToNotificationArea();
+			Lame.#moveChatbarButtonToNotificationArea();
 			log("Chat Notifications setting changed to 'cards': removed standalone Messenger button from notifications area.")
 		}
 	}
@@ -222,17 +222,17 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 	}
 
 	async onCreateChatMessage(msg, _options, _senderUserId) {
-		if (Lame.isPublicMessage(msg)
-			|| !Lame.isWhisperForMe(msg)
-			|| Lame.isMessageGameSystemGenerated(msg)
-			|| Lame.isMessageGameSystemSpecificRoll(msg)
-			|| Lame.isMessageModuleGenerated(msg)
+		if (Lame.#isPublicMessage(msg)
+			|| !Lame.#isWhisperForMe(msg)
+			|| Lame.#isMessageGameSystemGenerated(msg)
+			|| Lame.#isMessageGameSystemSpecificRoll(msg)
+			|| Lame.#isMessageModuleGenerated(msg)
 		) return;
 
-		await Lame.handleIncomingPrivateMessage(msg);
+		await Lame.#handleIncomingPrivateMessage(msg);
 	}
 
-	beautifyHistory() {
+	#beautifyHistory() {
 		// TODO: I think this is called too often and the output should be cached if it isn't already.
 		let beautified = [];
 
@@ -257,18 +257,18 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 	async populateHistoryFromWorldMessages() {
 		const worldMessages = game.collections.get("ChatMessage").contents;
 		for (const msg of worldMessages) {
-			if (this.isPublicMessage(msg)
-				|| this.isMessageGameSystemGenerated(msg)
-				|| this.isMessageGameSystemSpecificRoll(msg)
-				|| this.isMessageModuleGenerated(msg)
+			if (this.#isPublicMessage(msg)
+				|| this.#isMessageGameSystemGenerated(msg)
+				|| this.#isMessageGameSystemSpecificRoll(msg)
+				|| this.#isMessageModuleGenerated(msg)
 			) continue;
 
 			if (msg.isAuthor) {
-				this.addOutgoingMessageToHistory(msg);
+				this.#addOutgoingMessageToHistory(msg);
 				continue;
 			}
 
-			if (this.isWhisperForMe(msg))
+			if (this.#isWhisperForMe(msg))
 				this.#addIncomingMessageToHistory(msg);
 
 			// Everything left are public messages and are not processed.
@@ -293,9 +293,9 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 		await super.render(false, { parts: [partId] }); // Note: This calls SUPER directly.
 	}
 
-	async renderHistoryPartial() {
+	async #renderHistoryPartial() {
 		await this.renderPart("history");
-		this.scrollHistoryToBottom();
+		this.#scrollHistoryToBottom();
 	}
 
 	// Without this, when pressing Ctrl+M while window is already shown, the window is incorrectly re-rendered fully.
@@ -305,7 +305,7 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 
 	_canDetach() { return false; }
 
-	scrollHistoryToBottom() {
+	#scrollHistoryToBottom() {
 		const history = this.parts.history;
 		history.scrollTop = history.scrollHeight;
 	}
@@ -367,7 +367,7 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 		await Lame.renderPart('users');
 	}
 
-	sendWhisperTo(userIds, msg) {
+	#sendWhisperTo(userIds, msg) {
 		const chatData = {
 			user: game.user.id,
 			content: msg,
@@ -378,11 +378,11 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 
 	async _onKeyPressEvent(event) {
 		if ((event.code === "Enter") && event.ctrlKey) {
-			await this.sendMessage();
+			await this.#sendMessage();
 		}
 	}
 
-	async sendMessage() {
+	async #sendMessage() {
 		// Get message text:
 		const messageText = Lame.ui.messageField.value;
 		if (messageText.length === 0) {
@@ -402,16 +402,16 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 		}
 
 		// Send whisper(s):
-		this.sendWhisperTo(selectedUserIds, messageText);
+		this.#sendWhisperTo(selectedUserIds, messageText);
 		const selectedUserNames = this.#mapUsersIdsToNames(selectedUserIds);
-		this.addOutgoingTextToHistory(selectedUserNames, messageText);
-		await this.renderHistoryPartial();
+		this.#addOutgoingTextToHistory(selectedUserNames, messageText);
+		await this.#renderHistoryPartial();
 
 		// Clear message input field for next text:
 		Lame.ui.messageField.value = '';
 	}
 
-	async handleIncomingPrivateMessage(msg) {
+	async #handleIncomingPrivateMessage(msg) {
 		if (getSetting("showNotificationForNewWhisper")) {
 			ui.notifications.info(
 				`${localize("LAME.IncomingWhisperFrom")} ${msg.author.name}`,
@@ -424,7 +424,7 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 
 		if (!this.rendered) return this.render();
 
-		await this.renderHistoryPartial();
+		await this.#renderHistoryPartial();
 	}
 
 	async playNotificationSound() {
@@ -466,23 +466,23 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 		return ids.map(id => getUserNameFromId(id, this.users));
 	}
 
-	addOutgoingMessageToHistory(msg) {
+	#addOutgoingMessageToHistory(msg) {
 		const recipientNames = this.#mapUsersIdsToNames(msg.whisper);
-		this.addOutgoingTextToHistory(recipientNames, msg.content, msg.timestamp);
+		this.#addOutgoingTextToHistory(recipientNames, msg.content, msg.timestamp);
 	}
 
-	addOutgoingTextToHistory(recipientNames, text, timestamp = null) {
+	#addOutgoingTextToHistory(recipientNames, text, timestamp = null) {
 		if (!timestamp) timestamp = Date.now();
 		const conjunctedRecipientNames = i18nLongConjunct(recipientNames);
 		// As Foundry can only send messages to a single recipient, the conjunction is only kept for in-memory history.
 		this.history.push([timestamp, 'out', conjunctedRecipientNames, text]);
 	}
 
-	isPublicMessage(msg) {
+	#isPublicMessage(msg) {
 		return !msg.whisper.length;
 	}
 
-	isWhisperForMe(msg) {
+	#isWhisperForMe(msg) {
 		if (msg.isAuthor      // outgoing whispers,
 			|| !msg.visible   // whispers where the current user is neither author nor recipient,
 			|| msg.isRoll     // and private dice rolls.
@@ -491,7 +491,7 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 		return true;
 	}
 
-	isMessageGameSystemGenerated(msg) {
+	#isMessageGameSystemGenerated(msg) {
 		const systemGens = [
 			'<h3 class="nue">Getting Started</h3>',       // core: welcome to new world
 			'<h3 class="nue">Inviting Your Players</h3>', // core
@@ -502,7 +502,7 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 		return systemGens.some((item) => msg.content.includes(item));
 	}
 
-	isMessageGameSystemSpecificRoll(msg) {
+	#isMessageGameSystemSpecificRoll(msg) {
 		if (msg._stats?.systemId === 'wfrp4e' && ( // Warhammer Fantasy 4e (system doesn't implement #isRoll)
 			msg.type === 'test' // skill or attribute tests
 			|| msg.type === 'handler' // opposed test handler messages
@@ -512,7 +512,7 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 		return false;
 	}
 
-	isMessageModuleGenerated(msg) {
+	#isMessageModuleGenerated(msg) {
 		const moduleWelcomes = [
 			'<div class="dice-so-nice">',  // Dice So Nice
 			'<p>Welcome to Plutonium!</p>' // Plutonium

--- a/scripts/lame.mjs
+++ b/scripts/lame.mjs
@@ -60,7 +60,7 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 
 	/**
 	 * The object holding HTML elements of LAME's UI for easy access.
-	 * @type {{chatbarButton: HTMLDivElement}}
+	 * @type {{chatbarButton: HTMLDivElement, messageField: HTMLDivElement}}
 	 */
 	ui = {};
 
@@ -110,15 +110,14 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 
 		// Attach actions to elements:
 		// TODO: Adopt AppV2's "actions" instead.
-		const html = $(this.element);
-
-		// TODO: try to avoid using jQuery, e.g.:
-		// this.element.querySelector("input[name=something]").addEventListener("click", /* ... */);
-
-		html.find('button.send').click(async _event => {
-			await this.sendMessage(html);
+		this.element.querySelector('button.send').addEventListener('click', async () => {
+			await this.sendMessage();
 		});
-		html.find('.message').on("keypress", event => this._onKeyPressEvent(event, html));
+
+		Lame.ui.messageField = this.element.querySelector('.message');
+		Lame.ui.messageField.addEventListener('keypress', async (event) => {
+			await this._onKeyPressEvent(event);
+		});
 
 		this.scrollHistoryToBottom();
 	}
@@ -377,26 +376,25 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 		ChatMessage.create(chatData);
 	}
 
-	async _onKeyPressEvent(event, html) {
+	async _onKeyPressEvent(event) {
 		if ((event.code === "Enter") && event.ctrlKey) {
-			await this.sendMessage(html);
+			await this.sendMessage();
 		}
 	}
 
-	async sendMessage(html) {
+	async sendMessage() {
 		// Get message text:
-		const messageField = html.find('.message'),
-			messageText = messageField.val();
+		const messageText = Lame.ui.messageField.value;
 		if (messageText.length === 0) {
 			ui.notifications.error(localize("LAME.Notification.NoMessageToSend"));
 			return;
 		}
 
 		// Get selected user(s):
-		const checkedUserElements = html.find('input[id^="lame-messenger-user-"]:checked');
+		const checkedUserElements = document.querySelectorAll('input[id^="lame-messenger-user-"]:checked');
 		let selectedUserIds = [];
-		checkedUserElements.each(function () {
-			selectedUserIds.push(this.id.replace('lame-messenger-user-', ''));
+		checkedUserElements.forEach((user) => {
+			selectedUserIds.push(user.id.replace('lame-messenger-user-', ''));
 		});
 		if (selectedUserIds.length === 0) {
 			ui.notifications.error(localize("LAME.Notification.NoRecipientSelected"));
@@ -410,7 +408,7 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 		await this.renderHistoryPartial();
 
 		// Clear message input field for next text:
-		messageField.val('');
+		Lame.ui.messageField.value = '';
 	}
 
 	async handleIncomingPrivateMessage(msg) {

--- a/scripts/lame.mjs
+++ b/scripts/lame.mjs
@@ -1,13 +1,12 @@
-import {log} from "./helpers/log.mjs";
-
-const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;
-
-import {localize, MODULE_ID, MODULE_ICON_CLASSES, TEMPLATE_PARTS_PATH} from "./config.mjs";
+import {localize, MODULE_ID, MODULE_ICON_CLASSES, TEMPLATE_PARTS_PATH, SOUNDS_PATH} from "./config.mjs";
 import {getSetting, registerSettings} from "./settings.mjs";
 import {registerKeybindings} from "./keybindings.mjs";
 import {registerHandlebarsHelpers} from "./helpers/handlebars-helpers.mjs";
 import {formatDateYYYYMMDD, formatTimeHHMMSS, isToday} from "./helpers/date-time-helpers.mjs";
 import {i18nLongConjunct} from "./helpers/i18n.mjs";
+import {log} from "./helpers/log.mjs";
+
+const {ApplicationV2, HandlebarsApplicationMixin} = foundry.applications.api;
 
 export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 
@@ -150,7 +149,7 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 					aria-pressed="false"></button>
 				</div>`;
 		}
-		
+
 		let chatbarButton = (game.release.generation < 13)
 			? foundry.applications.parseHTML(chatbarButtonHtml)
 			: foundry.utils.parseHTML(chatbarButtonHtml);
@@ -160,7 +159,7 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 
 		return chatbarButton;
 	}
-	
+
 	static onCollapseSidebar(_app, collapsed) {
 		if (game.release.generation < 13) return;
 
@@ -182,7 +181,7 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 	static moveChatbarButtonToSidebar() {
 		const chatbarButton = game.modules.get(MODULE_ID).instance.chatbarButton;
 		chatbarButton.classList.remove('standalone-for-pip'); // In case this is present.
-		
+
 		// TODO: Check if there is a Foundry way to use a scoped sidebar part of the DOM instead of document.
 		const selector = (game.release.generation < 14) ? "#roll-privacy" : "#message-modes";
 		document.querySelector(selector).after(chatbarButton);
@@ -200,10 +199,10 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 	// v13+: Add/Remove standalone Messenger button when chat notification is set to pip/cards, respectively.
 	static onClientSettingChanged(settingPath, options) {
 		if (settingPath !== "core.uiConfig" || game.release.generation < 13) return;
-		
+
 		const instance = game.modules.get(MODULE_ID).instance,
 			chatbarButton = instance.chatbarButton;
-		
+
 		if (options.chatNotifications === "pip") {
 			LAME.addChatbarButtonToNotificationAreaAsStandalone();
 			log("Chat Notifications setting changed to 'pip': added Messenger button as standalone to notifications area.")
@@ -441,7 +440,7 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 		 * According to browser network inspection, the file is at least not requested multiple times.
 		 */
 		await game.audio.create({
-			src: "modules/lame-messenger/sounds/pst-pst.ogg",
+			src: `${SOUNDS_PATH}/pst-pst.ogg`,
 			context: game.audio.interface,
 			singleton: false,
 			preload: true,

--- a/scripts/module.mjs
+++ b/scripts/module.mjs
@@ -1,14 +1,19 @@
-import {LAME} from "./lame.mjs";
+import {LAME, Lame} from "./lame.mjs";
 import {getSetting} from "./settings.mjs";
-import {MODULE_ICON_CLASSES, MODULE_ID} from "./config.mjs";
+import {MODULE_ICON_CLASSES} from "./config.mjs";
 import {log} from "./helpers/log.mjs";
 
-Hooks.once('init', LAME.init); // this feels VERY early in Foundry's initialisation...
+Hooks.once('init', LAME.init);
 
 Hooks.once('ready', async () => {
-	const instance = game.modules.get(MODULE_ID).instance;
-	instance.computeUsersData(); // TODO: Look into this again as this doesn't seem to be the intended way...
-	await instance.populateHistoryFromWorldMessages();
+	Lame.computeUsersData();
+	await Lame.populateHistoryFromWorldMessages();
+
+	Hooks.on("collapseSidebar", Lame.onCollapseSidebar);
+	Hooks.on("changeSidebarTab", Lame.onChangeSidebarTab);
+	Hooks.on("createChatMessage", Lame.onCreateChatMessage);
+	Hooks.on('userConnected', Lame.computeUsersDataAndRenderPartial); // Update internal user list when user (dis)connects.
+	Hooks.on('clientSettingChanged', Lame.onClientSettingChanged);
 
 	if (game.release.generation > 12) {
 		const settingPipOrCards = game.settings.get('core', 'uiConfig').chatNotifications; // "cards" | "pip" (default)
@@ -16,9 +21,9 @@ Hooks.once('ready', async () => {
 			// TODO: Check if there is a better way for the initial adding of the button to the notification area.
 			//   Could use `renderChatLog` (or check if e.g. `renderChatNotification` exists). But I'd say it's fine for now.
 			// Initial display button in notification area if sidebar is collapsed:
-			if (!ui.sidebar.expanded) LAME.onCollapseSidebar(undefined, true);
+			if (!ui.sidebar.expanded) Lame.onCollapseSidebar(undefined, true);
 		} else {
-			LAME.addChatbarButtonToNotificationAreaAsStandalone();
+			Lame.addChatbarButtonToNotificationAreaAsStandalone();
 		}
 	}
 });
@@ -32,7 +37,7 @@ Hooks.on('renderSceneControls', (_controls, html) => {
 			</li>`;
 	let scenecontrolButton = foundry.applications.parseHTML(scenecontrolButtonHtml);
 	scenecontrolButton.addEventListener('click', async (_event) => {
-		await game.modules.get(MODULE_ID).instance.show();
+		await Lame.show();
 	});
 
 	html.find('.control-tools').find('.scene-control').last().after(scenecontrolButton);
@@ -45,15 +50,5 @@ Hooks.on("renderSidebarTab", async (app, html, _data) => {
 
 	if (app.tabName !== "chat" || !getSetting("buttonInChatControls")) return;
 
-	const chatbarButton = game.modules.get(MODULE_ID).instance.chatbarButton;
-	html.find("#chat-controls select.roll-type-select").after(chatbarButton);
+	html.find("#chat-controls select.roll-type-select").after(Lame.ui.chatbarButton);
 });
-
-Hooks.on("collapseSidebar", LAME.onCollapseSidebar);
-Hooks.on("changeSidebarTab", LAME.onChangeSidebarTab);
-Hooks.on("createChatMessage", LAME.onCreateChatMessage);
-
-// Update internal player list when user (dis)connects:
-Hooks.on('userConnected', LAME.computeUsersDataAndRenderPartial);
-
-Hooks.on('clientSettingChanged', LAME.onClientSettingChanged);

--- a/scripts/module.mjs
+++ b/scripts/module.mjs
@@ -9,7 +9,7 @@ Hooks.once('ready', async () => {
 	const instance = game.modules.get(MODULE_ID).instance;
 	instance.computeUsersData(); // TODO: Look into this again as this doesn't seem to be the intended way...
 	await instance.populateHistoryFromWorldMessages();
-	
+
 	if (game.release.generation > 12) {
 		const settingPipOrCards = game.settings.get('core', 'uiConfig').chatNotifications; // "cards" | "pip" (default)
 		if (settingPipOrCards === 'cards') {
@@ -26,7 +26,7 @@ Hooks.once('ready', async () => {
 // v12: Add button to scene controls toolbar:
 Hooks.on('renderSceneControls', (_controls, html) => {
 	if (!getSetting("buttonInSceneControlToolbar") || game.release.generation > 12) return;
-	
+
 	const scenecontrolButtonHtml = `<li class="scene-control control-tool toggle" data-tooltip="LAME.Module.ShortTitle">
 				<i class="${MODULE_ICON_CLASSES}"></i>
 			</li>`;
@@ -34,7 +34,7 @@ Hooks.on('renderSceneControls', (_controls, html) => {
 	scenecontrolButton.addEventListener('click', async (_event) => {
 		await game.modules.get(MODULE_ID).instance.show();
 	});
-	
+
 	html.find('.control-tools').find('.scene-control').last().after(scenecontrolButton);
 	log('renderSceneControls > button added')
 });
@@ -44,7 +44,7 @@ Hooks.on("renderSidebarTab", async (app, html, _data) => {
 	if (game.release.generation > 12) return;
 
 	if (app.tabName !== "chat" || !getSetting("buttonInChatControls")) return;
-	
+
 	const chatbarButton = game.modules.get(MODULE_ID).instance.chatbarButton;
 	html.find("#chat-controls select.roll-type-select").after(chatbarButton);
 });

--- a/scripts/settings.mjs
+++ b/scripts/settings.mjs
@@ -1,5 +1,5 @@
 import {MODULE_ID} from "./config.mjs";
-import {LAME} from "./lame.mjs";
+import {Lame, LAME} from "./lame.mjs";
 
 export function registerSettings() {
 	const isCoreV12orLower = game.release.generation < 13;
@@ -97,7 +97,7 @@ export function registerSettings() {
 		default: [],
 		requiresReload: false,
 		onChange: async() => {
-			await LAME.computeUsersDataAndRenderPartial();
+			await Lame.computeUsersDataAndRenderPartial();
 		}
 	});
 }

--- a/scripts/settings.mjs
+++ b/scripts/settings.mjs
@@ -1,5 +1,5 @@
 import {MODULE_ID} from "./config.mjs";
-import {Lame, LAME} from "./lame.mjs";
+import {Lame} from "./lame.mjs";
 
 export function registerSettings() {
 	const isCoreV12orLower = game.release.generation < 13;
@@ -33,7 +33,7 @@ export function registerSettings() {
 		default: true,
 		requiresReload: false,
 		onChange: value => {
-			game.modules.get(MODULE_ID).instance.settings.playNotificationSound = value;
+			Lame.settings.playNotificationSound = value;
 		}
 	});
 
@@ -68,7 +68,7 @@ export function registerSettings() {
 		type: Boolean,
 		default: false,
 		onChange: async() => {
-			await LAME.computeUsersDataAndRenderPartial();
+			await Lame.computeUsersDataAndRenderPartial();
 		}
 	});
 


### PR DESCRIPTION
Primarily, fc4cae5986cce407c6612ba973ec849f1aaa71a1 improves LAME class' members encapsulation.

Also:
- 16caffe71ad69af47bdd181efe3b4a53361f93f6 moves many members from class to instance:
By exporting the instance as `Lame`, this greatly simplifies the logic (no more need to explicitly expose the instance and access it via `game.modules.get(MODULE_ID).instance`) and makes the code easier to understand; with the added benefit of reducing the number of public members.
- ca0a760e97163bfef841f6f7e8c5b51a54b3ab89 removes the last remaining usage of jQuery:
  For some (if not all) (Hook) calls, Foundry v13 changed the returned `html` object from being a jQuery object to its plain HTML element. To avoid handling two different logics throughout the module, this now removes the 1 remaining case where jQuery was used.
- 56ced37bb62a43f40c189bc0dc32cc38ae6c4e8b centralises path configuration and does some cleaning-up.