### PR TITLE
Expose Foundry API to IDE and refactoring

### DIFF
--- a/.d.ts
+++ b/.d.ts
@@ -1,0 +1,11 @@
+declare global {
+    // Not a real extension of course but simplest way to expose Foundry's API to the IDE.
+    /**
+     * A simple event framework used throughout Foundry Virtual Tabletop.
+     * When key actions or events occur, a "hook" is defined where user-defined callback functions can execute.
+     * This class manages the registration and execution of hooked callback functions.
+     */
+    class Hooks extends foundry.helpers.Hooks {}
+    const fromUuid = foundry.utils.fromUuid;
+    const fromUuidSync = foundry.utils.fromUuidSync;
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "ignorePatterns": [
+    "foundryvtt-*/**/*"
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ tmp/
 
 # Foundry VTT's file used to lock module, preventing automatic updates:
 *.lock
+
+# IntelliJ / Intellisense setup based on: https://foundryvtt.wiki/en/development/guides/improving-intellisense
+/foundryvtt-*/

--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ This module can be installed automatically from the Foundry Virtual Tabletop mod
 ## 💡 Planned features
 
 - Tabbed chat for each user
-- Configurable notification sound
 - Detachable messenger window (pop-out browser window)
 - Configurable keyboard shortcuts (insert line break while typing message, and send message)
 - Option to show the character's portrait image instead of the user's avatar if the user has an associated actor

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "module": "ES2022",
+    "target": "ES2022",
+    "paths": {
+      "@client/*": ["./foundryvtt-14-365/client/*"],
+      "@common/*": ["./foundryvtt-14-365/common/*"]
+    }
+  },
+  "exclude": ["node_modules", "**/node_modules/*"],
+  "include": ["./module.mjs",
+    "foundryvtt-14-365/client/client.mjs",
+    "foundryvtt-14-365/client/global.d.mts",
+    "foundryvtt-14-365/common/global.d.mts",
+    ".d.ts"],
+  "typeAcquisition": {
+    "include": ["jquery"]
+  }
+}

--- a/scripts/lame.mjs
+++ b/scripts/lame.mjs
@@ -88,7 +88,7 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 
 	// Provides template parts with scoped dynamic data:
 	/** @override */
-	async _preparePartContext(partId, context) {
+	async _preparePartContext(partId, context, options) {
 		switch ( partId ) {
 			case "history":
 				context.history = this.#beautifyHistory();
@@ -373,13 +373,13 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 		await Lame.renderPart('users');
 	}
 
-	#sendWhisperTo(userIds, msg) {
+	async #sendWhisperTo(userIds, msg) {
 		const chatData = {
 			user: game.user.id,
 			content: msg,
 			whisper: userIds
 		};
-		ChatMessage.create(chatData);
+		await ChatMessage.create(chatData);
 	}
 
 	async _onKeyPressEvent(event) {
@@ -408,7 +408,7 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 		}
 
 		// Send whisper(s):
-		this.#sendWhisperTo(selectedUserIds, messageText);
+		await this.#sendWhisperTo(selectedUserIds, messageText);
 		const selectedUserNames = this.#mapUsersIdsToNames(selectedUserIds);
 		this.#addOutgoingTextToHistory(selectedUserNames, messageText);
 		await this.#renderHistoryPartial();

--- a/scripts/lame.mjs
+++ b/scripts/lame.mjs
@@ -208,7 +208,9 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 
 	// v13+: Add/Remove standalone Messenger button when chat notification is set to pip/cards, respectively.
 	onClientSettingChanged(settingPath, options) {
-		if (settingPath !== "core.uiConfig" || game.release.generation < 13) return;
+		if (settingPath !== "core.uiConfig"
+			|| game.release.generation < 13
+			|| (ui.sidebar.expanded && ui.sidebar.tabGroups.primary === "chat")) return;
 
 		if (options.chatNotifications === "pip") {
 			Lame.addOpenerButtonToNotificationAreaAsStandalone();

--- a/scripts/lame.mjs
+++ b/scripts/lame.mjs
@@ -40,7 +40,7 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 
 	/** @override */
 	static PARTS = {
-		// Can be access like this: this.constructor.PARTS[partId]
+		// Can be accessed like this: this.constructor.PARTS[partId]
 		users: {
 			id: "users",
 			classes: ["users"],
@@ -89,7 +89,7 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 	// Provides template parts with scoped dynamic data:
 	/** @override */
 	async _preparePartContext(partId, context, options) {
-		switch ( partId ) {
+		switch (partId) {
 			case "history":
 				context.history = this.#beautifyHistory();
 				break;
@@ -100,8 +100,7 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 		return context;
 	}
 
-	_onRender(_context, _options) {
-	}
+	_onRender(_context, _options) { }
 
 	_onFirstRender(_context, _options) {
 		/* Create div and move some of the partial elements into it. This is needed to maintain the ability to re-render
@@ -318,7 +317,6 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 		history.scrollTop = history.scrollHeight;
 	}
 
-
 	/** Return object with relevant user data.
 	 *  @type {Object}
 	 *  @example
@@ -337,16 +335,16 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 			// Exclude inactive user unless inactive users should be shown:
 			if (!user.active && !showInactiveUsers) return true;
 
+			// Foundry v13+:
+			if (usersToExclude instanceof Set
+				&& usersToExclude.size > 0
+				&& usersToExclude.has(user.id)
+			) return true;
+
 			// Foundry v12:
 			if (Array.isArray(usersToExclude)
 				&& usersToExclude.length > 0
 				&& usersToExclude.includes(user.id)
-			) return true;
-
-			// Foundry v13:
-			if (usersToExclude instanceof Set
-				&& usersToExclude.size > 0
-				&& usersToExclude.has(user.id)
 			) return true;
 
 			return false;
@@ -466,9 +464,7 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 	#mapUsersIdsToNames(ids) {
 		function getUserNameFromId(id, users) {
 			// If user does not exist, it was either deleted in the world, or is excluded via settings.
-			if (!users[id]) return "unknown";
-
-			return users[id].name;
+			return (!users[id]) ? "unknown" : users[id].name;
 		}
 
 		return ids.map(id => getUserNameFromId(id, this.users));
@@ -487,16 +483,13 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 	}
 
 	#isPublicMessage(msg) {
-		return !msg.whisper.length;
+		return !msg.whisper.length; // no whisper recipients
 	}
 
 	#isWhisperForMe(msg) {
-		if (msg.isAuthor      // outgoing whispers,
+		return !(msg.isAuthor // outgoing whispers,
 			|| !msg.visible   // whispers where the current user is neither author nor recipient,
-			|| msg.isRoll     // and private dice rolls.
-		) return false;
-
-		return true;
+			|| msg.isRoll);   // and private dice rolls.
 	}
 
 	#isMessageGameSystemGenerated(msg) {
@@ -511,13 +504,11 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 	}
 
 	#isMessageGameSystemSpecificRoll(msg) {
-		if (msg._stats?.systemId === 'wfrp4e' && ( // Warhammer Fantasy 4e (system doesn't implement #isRoll)
-			msg.type === 'test' // skill or attribute tests
+		return msg._stats?.systemId === 'wfrp4e' && ( // Warhammer Fantasy 4e (system doesn't implement #isRoll)
+			msg.type === 'test'       // skill or attribute tests
 			|| msg.type === 'handler' // opposed test handler messages
 			|| msg.type === 'opposed' // opposed test results
-		)) return true;
-
-		return false;
+		);
 	}
 
 	#isMessageModuleGenerated(msg) {

--- a/scripts/lame.mjs
+++ b/scripts/lame.mjs
@@ -60,7 +60,7 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 
 	/**
 	 * The object holding HTML elements of LAME's UI for easy access.
-	 * @type {{chatbarButton: HTMLDivElement, messageField: HTMLDivElement}}
+	 * @type {{openerButton: HTMLDivElement, messageField: HTMLDivElement}}
 	 */
 	ui = {};
 
@@ -142,28 +142,28 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 		Lame.ui.chatbarButton = Lame.#generateChatbarButton(); // TODO: Rename it as it's not always in the chatbar.
 	}
 
-	#generateChatbarButton() {
-		let chatbarButtonHtml;
+	#generateOpenerButton() {
+		let openerButtonHtml;
 		if (game.release.generation < 13) {
-			chatbarButtonHtml = `
+			openerButtonHtml = `
 				<a aria-label="${localize("LAME.Module.ShortTitle")}" role="button" class="lame-messenger" data-tooltip="LAME.Module.ShortTitle">
 					<i class="${MODULE_ICON_CLASSES}"></i>
 				</a>`;
 		} else {
-			chatbarButtonHtml = `<div id="lame-messenger-button" class="split-button">
+			openerButtonHtml = `<div id="lame-messenger-button" class="split-button">
 					<button type="button" class="ui-control icon ${MODULE_ICON_CLASSES}" data-tooltip="LAME.Module.ShortTitle"
 					aria-pressed="false"></button>
 				</div>`;
 		}
 
-		let chatbarButton = (game.release.generation < 13)
-			? foundry.applications.parseHTML(chatbarButtonHtml)
-			: foundry.utils.parseHTML(chatbarButtonHtml);
-		chatbarButton.addEventListener('click', async (_event) => {
+		let openerButton = (game.release.generation < 13)
+			? foundry.applications.parseHTML(openerButtonHtml)
+			: foundry.utils.parseHTML(openerButtonHtml);
+		openerButton.addEventListener('click', async (_event) => {
 			await Lame.show();
 		});
 
-		return chatbarButton;
+		return openerButton;
 	}
 
 	onCollapseSidebar(_app, collapsed) {
@@ -172,32 +172,33 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 		// Inspired by ChatLog#_toggleNotifications()
 		const embedInput = (!collapsed && ui.chat.active);
 		// Here, as in all static functions (needed for Hooks), `this` is the Hook object.
-		if (embedInput) Lame.#moveChatbarButtonToSidebar()
-		else Lame.#moveChatbarButtonToNotificationArea();
+		if (embedInput) Lame.#moveOpenerButtonToSidebar()
+		else Lame.#moveOpenerButtonToNotificationArea();
 	}
 
 	onChangeSidebarTab(app) {
 		if (game.release.generation < 13) return;
 
 		// TODO: Check if this can be done differently without triggering so many times, possibly not doing anything at all.
-		//  Consider adding boolean member #chatbarVisible or similar.
-		if (app.id === "chat") Lame.#moveChatbarButtonToSidebar()
-		else Lame.#moveChatbarButtonToNotificationArea();
+		//  Consider adding boolean member #sidebarChatVisible or similar.
+		if (app.id === "chat") Lame.#moveOpenerButtonToSidebar()
+		else Lame.#moveOpenerButtonToNotificationArea();
 	}
 
-	#moveChatbarButtonToSidebar() {
-		this.ui.chatbarButton.classList.remove('standalone-for-pip'); // In case this is present.
+	#moveOpenerButtonToSidebar() {
+		this.ui.openerButton.classList.remove('standalone-for-pip'); // In case this is present.
 
 		// TODO: Check if there is a Foundry way to use a scoped sidebar part of the DOM instead of document.
 		const selector = (game.release.generation < 14) ? "#roll-privacy" : "#message-modes";
-		document.querySelector(selector).after(this.ui.chatbarButton);
+		document.querySelector(selector).after(this.ui.openerButton);
 	}
 
-	#moveChatbarButtonToNotificationArea() {
+	#moveOpenerButtonToNotificationArea() {
 		if (game.settings.get('core', 'uiConfig').chatNotifications === 'pip') {
-			Lame.addChatbarButtonToNotificationAreaAsStandalone();
+			Lame.addOpenerButtonToNotificationAreaAsStandalone();
 		} else {
-			document.getElementById("chat-controls").prepend(this.ui.chatbarButton);
+			// TODO: possibly store the queried element (test if that is a reference but it should be)
+			document.getElementById("chat-controls").prepend(this.ui.openerButton);
 		}
 	}
 
@@ -206,20 +207,20 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 		if (settingPath !== "core.uiConfig" || game.release.generation < 13) return;
 
 		if (options.chatNotifications === "pip") {
-			Lame.addChatbarButtonToNotificationAreaAsStandalone();
+			Lame.addOpenerButtonToNotificationAreaAsStandalone();
 			log("Chat Notifications setting changed to 'pip': added Messenger button as standalone to notifications area.")
 		} else if (options.chatNotifications === "cards") {
-			Lame.ui.chatbarButton.classList.remove('standalone-for-pip'); // Works.
+			Lame.ui.openerButton.classList.remove('standalone-for-pip'); // Works.
 			// Foundry calls `renderChatInput` hook before `clientSettingChanged` to render the `#chat-controls` element.
 			//   We can therefore move the button ourselves without using `Hooking.once("renderChatInput")` for timing.
-			Lame.#moveChatbarButtonToNotificationArea();
+			Lame.#moveOpenerButtonToNotificationArea();
 			log("Chat Notifications setting changed to 'cards': removed standalone Messenger button from notifications area.")
 		}
 	}
 
-	addChatbarButtonToNotificationAreaAsStandalone() {
-		document.getElementById("chat-notifications").append(Lame.ui.chatbarButton);
-		Lame.ui.chatbarButton.classList.add('standalone-for-pip');
+	addOpenerButtonToNotificationAreaAsStandalone() {
+		document.getElementById("chat-notifications").append(Lame.ui.openerButton);
+		Lame.ui.openerButton.classList.add('standalone-for-pip');
 	}
 
 	async onCreateChatMessage(msg, _options, _senderUserId) {

--- a/scripts/lame.mjs
+++ b/scripts/lame.mjs
@@ -60,9 +60,14 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 
 	/**
 	 * The object holding HTML elements of LAME's UI for easy access.
-	 * @type {{openerButton: HTMLDivElement, messageField: HTMLDivElement}}
 	 */
-	ui = {};
+	ui = {
+		openerButton: this.#generateOpenerButton(),
+		core: {
+			chatControls: document.getElementById("chat-controls")
+		},
+		messageField: null // Declaration here not needed but adding it signals the field's existence to the IDE.
+	};
 
 	/**
 	 * The internally relevant users' data. Populated by {@link computeUsersData}.
@@ -139,7 +144,6 @@ export class LAME extends HandlebarsApplicationMixin(ApplicationV2) {
 		registerHandlebarsHelpers();
 
 		Lame = new LAME();
-		Lame.ui.chatbarButton = Lame.#generateChatbarButton(); // TODO: Rename it as it's not always in the chatbar.
 	}
 
 	#generateOpenerButton() {

--- a/scripts/module.mjs
+++ b/scripts/module.mjs
@@ -23,7 +23,7 @@ Hooks.once('ready', async () => {
 			// Initial display button in notification area if sidebar is collapsed:
 			if (!ui.sidebar.expanded) Lame.onCollapseSidebar(undefined, true);
 		} else {
-			Lame.addChatbarButtonToNotificationAreaAsStandalone();
+			Lame.addOpenerButtonToNotificationAreaAsStandalone();
 		}
 	}
 });
@@ -50,5 +50,5 @@ Hooks.on("renderSidebarTab", async (app, html, _data) => {
 
 	if (app.tabName !== "chat" || !getSetting("buttonInChatControls")) return;
 
-	html.find("#chat-controls select.roll-type-select").after(Lame.ui.chatbarButton);
+	html.find("#chat-controls select.roll-type-select").after(Lame.ui.openerButton);
 });

--- a/scripts/settings.mjs
+++ b/scripts/settings.mjs
@@ -45,10 +45,10 @@ export function registerSettings() {
 		type: String,
 		default: DEFAULT_NOTIFICATION_SOUND_FILE,
 		filePicker: "audio",
-		onChange: value => {
+		onChange: async (value) => {
 			if (value === '') {
 				value = DEFAULT_NOTIFICATION_SOUND_FILE;
-				game.settings.set(MODULE_ID, 'notificationSoundFile', value);
+				await game.settings.set(MODULE_ID, 'notificationSoundFile', value);
 				// Setting the value to default triggers the onChange again. Since it only assigns the value to
 				//   the member in Lame, we can ignore it.
 			}
@@ -64,8 +64,8 @@ export function registerSettings() {
 		type: Boolean,
 		default: false,
 		requiresReload: false,
-		onChange: () => {
-			window.ui.controls.render();
+		onChange: async () => {
+			await window.ui.controls.render();
 		}
 	});
 

--- a/scripts/settings.mjs
+++ b/scripts/settings.mjs
@@ -36,7 +36,7 @@ export function registerSettings() {
 			Lame.settings.playNotificationSound = value;
 		}
 	});
-	
+
 	registerSetting("notificationSoundFile", {
 		name: "Notification sound file",
 		hint: 'The sound file to play as notification upon receiving a new whisper. Leave the field blank to reset to the default "pst-pst" sound.',
@@ -55,7 +55,7 @@ export function registerSettings() {
 			Lame.settings.notificationSoundFile = value;
 		}
 	});
-	
+
 	registerSetting('buttonInSceneControlToolbar', {
 		name: "LAME.Setting.ButtonInSceneControlToolbar",
 		hint: "LAME.Setting.ButtonInSceneControlToolbarHint",


### PR DESCRIPTION
- f046bdb980ba04819b1abbf09711d0e5797be99c prevents opener button from moving to incorrect place in chat sidebar when notification setting is changed while chat tab is currently active.
- 4598b6452e3fdf64e1f3fc55daaaa4a19e76d883 locally exposes Foundry's API to the IDE which leads to a few minor fixes.
- Also, some refactoring and typo fixes.