### PR TITLE
💚Add Dependabot config for GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# This file controls the configuration for the "Dependabot" service, used to keep dependencies updated.
+# Based on https://github.com/League-of-Foundry-Developers/FoundryVTT-Module-Template/blob/master/.github/workflows/main.yml
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# See the above link for the reason why "directory" is set to "/"
+version: 2
+updates:
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    open-pull-requests-limit: 10
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,5 @@
-# GitHub Actions workflow for creating a new FoundryVTT module release.
+# GitHub Actions workflow for creating a new FoundryVTT module release, based on
+# https://github.com/League-of-Foundry-Developers/FoundryVTT-Module-Template/blob/master/.github/workflows/main.yml
 #
 # Useful References:
 #   - https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions


### PR DESCRIPTION
In order to keep dependencies used in GitHub action (to check out the repo during releases) up-to-date, this adds Dependabot's config.

As the currently used [`actions/checkout`](https://github.com/actions/checkout) v4 is quite outdated (latest generation is v7) and building [release artefacts is failing](https://github.com/lucasmetzen/foundryvtt-messenger/actions/runs/32156825051), having Dependabot check the dependencies monthly is desirable.