### PR TITLE
🚑️Fix missing MODULE_ID import

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -19,3 +19,4 @@ assignees: lucasmetzen
     - [ ] Merge to `main`
 - [ ] Publish release
 - [ ] Verify new release on [Foundry's package page](https://foundryvtt.com/packages/lame-messenger)
+- [ ] Download module from Foundry VTT's catalogue and re-verify functionality 

--- a/scripts/lame.mjs
+++ b/scripts/lame.mjs
@@ -1,4 +1,4 @@
-import {localize, MODULE_ICON_CLASSES, TEMPLATE_PARTS_PATH} from "./config.mjs";
+import {localize, MODULE_ICON_CLASSES, MODULE_ID, TEMPLATE_PARTS_PATH} from "./config.mjs";
 import {getSetting, registerSettings} from "./settings.mjs";
 import {registerKeybindings} from "./keybindings.mjs";
 import {registerHandlebarsHelpers} from "./helpers/handlebars-helpers.mjs";


### PR DESCRIPTION
In commit 16caffe, the import of MODULE_ID into the main class was accidentally removed. This is now fixed.

### Explanation
I am locally using a slightly modified version of the module (different ID to denote it as the "dev branch") - on which I am also doing the testing on. There, the `MODULE_ID` is defined directly in the class.
This is done in order to be able to check if the module can be downloaded from the catalogue after a new release (no colliding IDs).
Because of this setup, I did not realise that I removed the "unused" import of the constant as the module loaded fine, and I did not re-verify that the downloaded update also works.

### Measures to avoid this in the future
I have amended the issue template "release checklist" by a new point to also verify the downloaded module's functionality after the release.
Since this is not ideal, I will look into changing the setup in a feasible way to catch such regressions before releasing to avoid emergency fixes.